### PR TITLE
issue #307 iOS 8 screenshot crash: add extra guards on screenshot code (might stop crash?)

### DIFF
--- a/Utils/Extensions/UIViewExtensions.swift
+++ b/Utils/Extensions/UIViewExtensions.swift
@@ -12,6 +12,10 @@ extension UIView {
     func screenshot(size: CGSize, offset: CGPoint? = nil, quality: CGFloat = 1) -> UIImage? {
         assert(0...1 ~= quality)
 
+        if size.width < 1 || size.height < 1 || superview == nil {
+            return nil
+        }
+
         let offset = offset ?? CGPointMake(0, 0)
         UIGraphicsBeginImageContextWithOptions(size, true, UIScreen.mainScreen().scale * quality)
         drawViewHierarchyInRect(CGRect(origin: offset, size: frame.size), afterScreenUpdates: false)


### PR DESCRIPTION
Issue #307. Not crashing in simulator, but drawViewHierarchyInRect has preconditions that size should be at least 1x1 and have a superview (according to others on StackOverflow who had similar crashes on older iOS versions)