### PR TITLE
Remove WKNavigationDelegate, which required fake WK* webkit objects.

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -148,7 +148,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
         return nil
     }
 
-    weak var navigationDelegate: WKNavigationDelegate? {
+    weak var navigationDelegate: WKCompatNavigationDelegate? {
         didSet {
             if let webView = webView {
                 webView.navigationDelegate = navigationDelegate

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKUIDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKUIDelegate.swift
@@ -125,16 +125,4 @@ extension BrowserViewController: WKUIDelegate {
 
         return false
     }
-
-    func webView(webView: WKWebView, decidePolicyForNavigationResponse navigationResponse: WKNavigationResponse, decisionHandler: (WKNavigationResponsePolicy) -> Void) {
-        if navigationResponse.canShowMIMEType {
-            decisionHandler(WKNavigationResponsePolicy.Allow)
-            return
-        }
-
-        let error = NSError(domain: ErrorPageHelper.MozDomain, code: Int(ErrorPageHelper.MozErrorDownloadsNotEnabled), userInfo: [NSLocalizedDescriptionKey: "Downloads aren't supported in Brave yet (but we're working on it)."])
-        guard let uiwebview = (webView as? ContainerWebView)?.legacyWebView else { assert(false) ; return }
-        ErrorPageHelper().showPage(error, forUrl: navigationResponse.response.URL!, inWebView: uiwebview)
-        decisionHandler(WKNavigationResponsePolicy.Allow)
-    }
 }

--- a/Client/Frontend/Reader/ReadabilityService.swift
+++ b/Client/Frontend/Reader/ReadabilityService.swift
@@ -41,7 +41,7 @@ class ReadabilityOperation: NSOperation, WKNavigationDelegate, ReadabilityBrowse
             let configuration = WKWebViewConfiguration()
             self.browser = Browser(configuration: configuration)
             self.browser.createWebview()
-            self.browser.navigationDelegate = self
+           /// self.browser.navigationDelegate = self
 
             if let readabilityBrowserHelper = ReadabilityBrowserHelper(browser: self.browser) {
                 readabilityBrowserHelper.delegate = self


### PR DESCRIPTION
This was originally done as a hack to quickly connect UIWebView code to use Firefox iOS interfaces without WKWebView. To conform to the interfaces in Fx iOS code, certain WKWebView API objects are needed, so I had faked them.

For one there is a minor memory leak reported with constructing parentless WKNavigation objects (actually, one is NEVER supposed to do this, but I did it anyway because of a time crunch).
Also, the code is difficult to follow with the fake objects being passed around (not to mention how confusing these fake objects are when reading the code).