### PR TITLE
adding a default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+**Did you search for similar issues before submitting this one?**
+
+**Describe the issue you encountered:**
+
+**Expected behavior:**
+
+- Device (iPhone5, iPhone6s plus, iPad 3, ?):
+
+- Brave Version:
+
+- Steps to reproduce:
+    1.
+    2.
+    3.
+
+- Screenshot if needed:
+
+- Any related issues:


### PR DESCRIPTION
Added a default issue template to organize and speed up bug reports. It follows the style of the laptop issue reports.