### PR TITLE
Httpse performance: in mem cache of 1st db query

### DIFF
--- a/brave/src/webfilters/HttpsEverywhere.swift
+++ b/brave/src/webfilters/HttpsEverywhere.swift
@@ -140,10 +140,13 @@ class HttpsEverywhere {
 
         let query = table.select(ids).filter(hostCol.like(domain))
 
-        var result = [Int]()
-
         if let cached = fifoCacheOfDomainToIds.getItem(domain) as? [Int] {
             return cached
+        }
+
+        var result = [Int]()
+        defer {
+            fifoCacheOfDomainToIds.addItem(domain, value: result)
         }
 
         if let row = db.prepare(query).generate().next() {
@@ -159,10 +162,7 @@ class HttpsEverywhere {
                 }
             }
 
-            fifoCacheOfDomainToIds.addItem(domain, value: result)
             return result
-        } else {
-            fifoCacheOfDomainToIds.addItem(domain, value: [])
         }
         return nil
     }

--- a/brave/src/webfilters/UrlProtocol.swift
+++ b/brave/src/webfilters/UrlProtocol.swift
@@ -10,6 +10,7 @@ class URLProtocol: NSURLProtocol {
 
     var connection: NSURLConnection?
     var disableJavascript = false
+    static var testShieldState: BraveShieldState?
 
     override class func canInitWithRequest(request: NSURLRequest) -> Bool {
         //print("Request #\(requestCount++): URL = \(request.mainDocumentURL?.absoluteString)")
@@ -23,7 +24,7 @@ class URLProtocol: NSURLProtocol {
 
         guard let url = request.URL else { return false }
 
-        let shieldState = getShields(request)
+        let shieldState = testShieldState != nil ? testShieldState! : getShields(request)
         if shieldState.isAllOff() {
             return false
         }

--- a/brave/tests_src/HttpsEverywhereTest.swift
+++ b/brave/tests_src/HttpsEverywhereTest.swift
@@ -28,4 +28,29 @@ class HttpsEverywhereTest: XCTestCase {
             XCTAssert(redirected != nil && redirected!.scheme.startsWith("https"), "failed:" + url)
         }
     }
+
+    private func doTest(httpseOn on: Bool, group: [String]) {
+        WebViewLoadTestUtils.httpseEnabled(on)
+        measureBlock({
+            WebViewLoadTestUtils.loadSites(self, sites: group)
+        })
+    }
+
+    func testTimeHttpseOn_A() {
+        doTest(httpseOn: true, group: groupA)
+    }
+
+    func testTimeHttpseOff_A() {
+        doTest(httpseOn: false, group: groupA)
+    }
+
+    func testTimeHttpseOn_B() {
+        doTest(httpseOn: true, group: groupB)
+    }
+
+    func testTimeHttpseOff_B() {
+        doTest(httpseOn: false, group: groupB)
+    }
+    
+
 }

--- a/brave/tests_src/WebViewLoadTest.swift
+++ b/brave/tests_src/WebViewLoadTest.swift
@@ -4,175 +4,135 @@ import XCTest
 @testable import Client
 import Shared
 
+
+var groupA = ["businessinsider.com", "kotaku.com", "cnn.com"]
+var groupB = ["imore.com", "nytimes.com"]
+
 class WebViewLoadTest: XCTestCase {
-  override func setUp() {
-    super.setUp()
-  }
 
-  override func tearDown() {
-    super.tearDown()
-  }
+    /* The following uses XCodes built-in performance measurement XCTest.measureBlock which has no way of handling
+     unexpectedly long loads. Ideally if the load takes >15s we would throw out the result.
+     I treat >15s as a load failure, but no test result is reported when that happens, and the test must
+     be repeated.
+     XCTest.measureBlock runs each test 10x.
+     */
 
-  func adblockOn(enable:Bool) {
-    if enable {
-      NSURLProtocol.registerClass(URLProtocol);
-    } else {
-      NSURLProtocol.unregisterClass(URLProtocol);
-    }
-  }
-
-  func loadSite(site:String, webview:BraveWebView) ->Bool {
-    let url = NSURL(string: "http://" + site)
-    expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
-    webview.loadRequest(NSURLRequest(URL: url!))
-    var isOk = true
-    waitForExpectationsWithTimeout(15) { (error:NSError?) -> Void in
-      if let _ = error {
-        isOk = false
-      }
+    private func doTest(shieldsOn shieldsOn: Bool, group: [String]) {
+        WebViewLoadTestUtils.urlProtocolEnabled(shieldsOn)
+        measureBlock({
+            WebViewLoadTestUtils.loadSites(self, sites: group)
+        })
     }
 
-    webview.stopLoading()
-    expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
-    webview.loadHTMLString("<html><head></head><body></body></html>", baseURL: nil)
-    waitForExpectationsWithTimeout(2, handler: nil)
-
-    return isOk
-  }
-
-
-  func loadSites(sites:[String]) {
-    let w = BraveWebView(frame: CGRectMake(0,0,200,200))
-    for site in sites {
-        print("\(site)")
-        self.loadSite(site, webview: w)
+    func testBraveDefaultShieldsOn_A() {
+        doTest(shieldsOn: true, group: groupA)
     }
-  }
 
-  /* The following uses XCodes built-in performance measurement XCTest.measureBlock which has no way of handling
-  unexpectedly long loads. Ideally if the load takes >15s we would throw out the result. 
-  I treat >15s as a load failure, but no test result is reported when that happens, and the test must 
-  be repeated.
-  XCTest.measureBlock runs each test 10x.
-  */
+    func testBraveDefaultShieldsOff_A() {
+        doTest(shieldsOn: false, group: groupA)
+    }
 
-  var groupA = ["businessinsider.com", "kotaku.com"]
-  var groupB = ["imore.com", "nytimes.com"]
+    func testBraveDefaultShieldsOn_B() {
+        doTest(shieldsOn: true, group: groupB)
+    }
 
-  func testAdBlockOn_A() {
-    adblockOn(true)
-    self.loadSites(self.groupA)
-    measureBlock({
-      self.loadSites(self.groupA)
-    })
-  }
+    func testBraveDefaultShieldsOff_B() {
+        doTest(shieldsOn: false, group: groupB)
+    }
 
-  func testAdBlockOff_A() {
-    adblockOn(false)
-    self.loadSites(self.groupA)
-    measureBlock({
-      self.loadSites(self.groupA)
-    })
-  }
+    // End of XCTest measureBlock
 
-  func testAdBlockOn_B() {
-    adblockOn(true)
-    self.loadSites(self.groupB)
-    measureBlock({
-      self.loadSites(self.groupB)
-    })
-  }
+    // Uses my own test timing, results aren't as detailed as the XCTest.measureBlock
+    func testTopSlowSites() {
+        let sites = ["nytimes.com", "macworld.com", "wired.com", "theverge.com",
+                     "businessinsider.com", "imore.com", "kotaku.com", "huffingtonpost.com"]
+        var dict = [String: (shieldsOn: [Double], shieldsOff: [Double])]()
 
-  func testAdBlockOff_B() {
-    adblockOn(false)
-    self.loadSites(self.groupB)
-    measureBlock({
-      self.loadSites(self.groupB)
-    })
-  }
+        for i in 0..<4 {
+            let shieldsOn = i % 2 == 0
+            WebViewLoadTestUtils.urlProtocolEnabled(shieldsOn)
+            //WebViewLoadTestUtils.httpseEnabled(shieldsOn)
 
-  // End of XCTest measureBlock
+            for site in sites {
+                let webview = BraveWebView(frame: CGRectMake(0,0,200,200))
 
-  // Uses my own test timing, results aren't as detailed as the XCTest.measureBlock
-  func testTopSlowSites() {
-    let sites = ["nytimes.com", "macworld.com", "wired.com", "theverge.com",
-      "businessinsider.com", "imore.com", "kotaku.com", "huffingtonpost.com"]
-    var dict = [String:[[Double]]]()
+                print("\(site)")
 
-    let webview = BraveWebView(frame: CGRectMake(0,0,200,200))
-    for _ in 0..<3 {
-      for i in 0..<2 {
-        adblockOn(i == 1)
+                // prime it
+                //loadSite(site, webview: webview)
 
-        for site in sites {
-          print("\(site)")
+                let timeStart = NSDate.timeIntervalSinceReferenceDate()
+                let ok = WebViewLoadTestUtils.loadSite(self, site: site, webview: webview)
+                if !ok {
+                    continue
+                }
+                let time = NSDate.timeIntervalSinceReferenceDate() - timeStart
 
-          // prime it
-          loadSite(site, webview: webview)
+                if time < 1 {
+                    print("(\(i)) skipping \(site), load too fast \(time)")
+                    continue
+                }
 
-          let timeStart = NSDate.timeIntervalSinceReferenceDate()
-          let ok = loadSite(site, webview: webview)
-          if !ok {
-            continue
-          }
-          let time = NSDate.timeIntervalSinceReferenceDate() - timeStart
+                if dict[site] == nil {
+                    dict[site] = (shieldsOn: [Double](), shieldsOff: [Double]())
+                }
 
-          if time < 1 {
-            print("(\(i)) skipping \(site), load too fast \(time)")
-            continue
-          }
-
-          if dict[site] == nil {
-            dict[site] = [[Double](), [Double]()]
-          }
-
-          dict[site]![i].append(time)
+                if shieldsOn {
+                    dict[site]!.shieldsOn.append(time)
+                } else {
+                    dict[site]!.shieldsOff.append(time)
+                }
+            }
         }
-      }
-    }
 
-    var countSitesWithFasterLoad = 0
-    var averages = [String:(Double, Double)]()
-    for (key, noBlockAndBlockArrays) in dict {
-      for i in 0..<2 {
-        let arr = noBlockAndBlockArrays[i]
-        let average = arr.reduce(0.0) { return ($0 + $1) } / Double(arr.count)
-        print("\(i) \(key) \(average)")
-        if i < 1 {
-          averages[key] = (average, 0.0)
-        } else {
-          averages[key] = (averages[key]!.0, average)
-          if (averages[key]!.1 < averages[key]!.0) {
-            countSitesWithFasterLoad++
-          }
+
+        var countSitesWithFasterLoad = 0
+        var averages = [String: (on: Double, off: Double)]()
+        for (site, arrays) in dict {
+            func average(isOn: Bool, arr: [Double]) {
+                let average = arr.reduce(0.0) { return ($0 + $1) } / Double(arr.count)
+                print("Shields On:\(isOn) \(site) \(average)")
+                if averages[site] == nil {
+                    averages[site] = (on: 0.0, off: 0.0)
+                }
+                if isOn {
+                    averages[site]!.on = average
+                } else {
+                    averages[site]!.off = average
+                }
+
+                if (averages[site]!.on > 0 && averages[site]!.off > 0 && averages[site]!.on < averages[site]!.off) {
+                    countSitesWithFasterLoad += 1
+                }
+            }
+            average(true, arr: arrays.shieldsOn)
+            average(false, arr: arrays.shieldsOff)
         }
-      }
+
+        XCTAssert(countSitesWithFasterLoad == sites.count, "Expected all sites to load faster with ad block")
     }
 
-    XCTAssert(countSitesWithFasterLoad == sites.count, "Expected all sites to load faster with ad block")
-  }
 
-
-#if TEST_ALEXA500
-  // If you have an hour+ to wait, this will run through a huge list of sites. 
-  // It is very useful to stress the app, you can watch memory, or just see if there are any major errors
-  // in the console.
-  func testStressUsingAlexa500() {
-    let w = BraveWebView(frame: CGRectMake(0,0,200,200))
-    var count = 0
-    for site in sites500 {
-      print("Site: \(count++) \(site)")
-      loadSite(site, webview: w)
+    #if TEST_ALEXA500
+    // If you have an hour+ to wait, this will run through a huge list of sites.
+    // It is very useful to stress the app, you can watch memory, or just see if there are any major errors
+    // in the console.
+    func testStressUsingAlexa500() {
+        let w = BraveWebView(frame: CGRectMake(0,0,200,200))
+        var count = 0
+        for site in sites500 {
+            print("Site: \(count += 1) \(site)")
+            WebViewLoadTestUtils.loadSite(self, site: site, webview: w)
+        }
     }
-  }
-#endif
-
-  func testOpenUrlUsingBraveSchema() {
-    expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
-    let site = "google.ca"
-    let ok = UIApplication.sharedApplication().openURL(
-      NSURL(string: "brave://open-url?url=https%253A%252F%252F" + site)!)
-    waitForExpectationsWithTimeout(10, handler: nil)
-    XCTAssert(ok, "open url failed for site: \(site)")
-  }
+    #endif
+    
+    func testOpenUrlUsingBraveSchema() {
+        expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
+        let site = "google.ca"
+        let ok = UIApplication.sharedApplication().openURL(
+            NSURL(string: "brave://open-url?url=https%253A%252F%252F" + site)!)
+        waitForExpectationsWithTimeout(10, handler: nil)
+        XCTAssert(ok, "open url failed for site: \(site)")
+    }
 }

--- a/brave/tests_src/WebViewLoadTestUtils.swift
+++ b/brave/tests_src/WebViewLoadTestUtils.swift
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import Foundation
+import XCTest
+@testable import Client
+import Shared
+
+class WebViewLoadTestUtils {
+    static func urlProtocolEnabled(enable:Bool) {
+        if enable {
+          NSURLProtocol.registerClass(URLProtocol);
+        } else {
+          NSURLProtocol.unregisterClass(URLProtocol);
+        }
+    }
+
+    static func httpseEnabled(enable: Bool) {
+        URLProtocol.testShieldState = BraveShieldState()
+        URLProtocol.testShieldState?.setState(BraveShieldState.kHTTPSE, on: enable)
+    }
+
+    static func loadSite(testCase: XCTestCase, site:String, webview:BraveWebView) ->Bool {
+        let url = NSURL(string: "http://" + site)
+        testCase.expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
+        webview.loadRequest(NSURLRequest(URL: url!))
+        var isOk = true
+        testCase.waitForExpectationsWithTimeout(15) { (error:NSError?) -> Void in
+            if let _ = error {
+                isOk = false
+            }
+        }
+
+        webview.stopLoading()
+        testCase.expectationForNotification(BraveWebViewConstants.kNotificationWebViewLoadCompleteOrFailed, object: nil, handler:nil)
+        webview.loadHTMLString("<html><head></head><body></body></html>", baseURL: nil)
+        testCase.waitForExpectationsWithTimeout(2, handler: nil)
+
+        return isOk
+    }
+
+
+    static func loadSites(testCase: XCTestCase, sites:[String]) {
+        let w = BraveWebView(frame: CGRectMake(0,0,200,200))
+        for site in sites {
+            print("\(site)")
+            self.loadSite(testCase, site: site, webview: w)
+        }
+    }
+}


### PR DESCRIPTION
HTTPSE has 2 database queries, only the 2nd was cached, this adds a cache on the 1st query also. 
Without this fix we see a 15% performance hit:
<img width="589" alt="screenshot 2016-08-07 15 53 13" src="https://cloud.githubusercontent.com/assets/5495083/17465000/289be24c-5cb9-11e6-88b9-b583180d27e6.png">

With this fix we can see the off/on times are about the same:
<img width="610" alt="screenshot 2016-08-07 15 48 11" src="https://cloud.githubusercontent.com/assets/5495083/17465007/411902f0-5cb9-11e6-8280-5c93950599f3.png">
