### PR TITLE
Brave shield fixes

### DIFF
--- a/brave/src/frontend/BraveTopViewController.swift
+++ b/brave/src/frontend/BraveTopViewController.swift
@@ -155,7 +155,7 @@ class BraveTopViewController : UIViewController {
         if panel === mainSidePanel {
             leftSidePanelButtonAndUnderlay?.selected = willShow
             leftSidePanelButtonAndUnderlay?.hideUnderlay(!willShow)
-        } else if !willShow && !panel.canShow {
+        } else if panel.view.hidden && !panel.canShow {
             return
         }
 

--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -356,9 +356,13 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
                     state = sender.on
                 }
             }
-            getApp().profile?.setBraveShieldForNormalizedDomain(site, state: (siteShieldKey, state))
-            (getApp().browserViewController as! BraveBrowserViewController).updateBraveShieldButtonState(animated: true)
-            BraveApp.getCurrentWebView()?.reload()
+            
+            //push these other updates asynchronously rather than within the loop of the UI event
+            dispatch_async(dispatch_get_main_queue()) {
+                getApp().profile?.setBraveShieldForNormalizedDomain(site, state: (siteShieldKey, state))
+                (getApp().browserViewController as! BraveBrowserViewController).updateBraveShieldButtonState(animated: true)
+                BraveApp.getCurrentWebView()?.reload()
+            }
         }
 
         switch (sender) {

--- a/brave/src/webfilters/SafeBrowsingError.html
+++ b/brave/src/webfilters/SafeBrowsingError.html
@@ -22,6 +22,9 @@
         </style>
     </head>
     <body>
+        <script>
+            document['BraveSafeBrowsingPageResult'] = "true"
+            </script>
         <br /><br />
         <div class="container">
             <div class="center">

--- a/brave/src/webview/BraveWebView.swift
+++ b/brave/src/webview/BraveWebView.swift
@@ -113,6 +113,8 @@ class BraveWebView: UIWebView {
     var removeBvcObserversOnDeinit: ((UIWebView) -> Void)?
     var removeProgressObserversOnDeinit: ((UIWebView) -> Void)?
 
+    var safeBrowsingBlockTriggered:Bool = false
+    
     var prevDocumentLocation = ""
     var estimatedProgress: Double = 0
     var title: String = "" {
@@ -384,6 +386,10 @@ class BraveWebView: UIWebView {
             return
         }
         internalIsLoadingEndedFlag = true
+        
+        if safeBrowsingBlockTriggered {
+            return
+        }
 
         // Wait a tiny bit in hopes the page contents are updated. Load completed doesn't mean the UIWebView has done any rendering (or even has the JS engine for the page ready, see the delay() below)
         delay(0.1) {
@@ -525,33 +531,6 @@ class BraveWebView: UIWebView {
         js += "script.innerHTML = '\(css)';"
         js += "document.head.appendChild(script);"
         LegacyUserContentController.injectJsIntoAllFrames(self, script: js)
-    }
-
-    var safeBrowsingCheckIsEmptyPageTimer = NSTimer()
-
-    func safeBrowsingCheckIsEmptyPageTimeout(timer: NSTimer) {
-        let urlInfo = timer.userInfo as? NSURL
-        safeBrowsingCheckIsEmptyPageTimer.invalidate()
-
-        ensureMainThread {
-            let contents = self.stringByEvaluatingJavaScriptFromString("document.body")
-            if contents?.isEmpty ?? true {
-                let path = NSBundle.mainBundle().pathForResource("SafeBrowsingError", ofType: "html")!
-                let src = try! NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
-                self.loadHTMLString(src, baseURL: nil)
-            }
-            delay(0.2) {
-                [weak self] in
-                self?.setUrl(urlInfo, reliableSource: true)
-            }
-        }
-    }
-
-    func safeBrowsingCheckIsEmptyPage(url: NSURL?) {
-        if safeBrowsingCheckIsEmptyPageTimer.valid {
-            return
-        }
-        safeBrowsingCheckIsEmptyPageTimer = NSTimer.scheduledTimerWithTimeInterval(0.5, target: self, selector: #selector(safeBrowsingCheckIsEmptyPageTimeout), userInfo: url, repeats: false)
     }
 
     enum ShieldStatUpdate {
@@ -704,7 +683,7 @@ extension BraveWebView: UIWebViewDelegate {
 
     func webViewDidStartLoad(webView: UIWebView) {
         backForwardList.update()
-
+        
         if let nd = navigationDelegate {
             // this triggers the network activity spinner
             globalContainerWebView.legacyWebView = self
@@ -730,6 +709,11 @@ extension BraveWebView: UIWebViewDelegate {
         guard let pageInfo = stringByEvaluatingJavaScriptFromString("document.readyState.toLowerCase() + '|' + document.title") else {
             return
         }
+        
+        if let isSafeBrowsingBlock = stringByEvaluatingJavaScriptFromString("document['BraveSafeBrowsingPageResult']") {
+
+            safeBrowsingBlockTriggered = (isSafeBrowsingBlock as NSString).boolValue
+        }
         let pageInfoArray = pageInfo.componentsSeparatedByString("|")
 
         let readyState = pageInfoArray.first // ;print("readyState:\(readyState)")
@@ -746,7 +730,6 @@ extension BraveWebView: UIWebViewDelegate {
         if (error?.code == NSURLErrorCancelled) {
             return
         }
-
         print("didFailLoadWithError: \(error)")
 
         if (error?.domain == NSURLErrorDomain) {
@@ -818,7 +801,7 @@ extension BraveWebView : NSURLConnectionDelegate, NSURLConnectionDataDelegate {
         challenge.sender?.continueWithoutCredentialForAuthenticationChallenge(challenge)
         loadingUnvalidatedHTTPSPage = false
     }
-    
+
     func connection(connection: NSURLConnection, didReceiveResponse response: NSURLResponse) {
         guard let url = URL else { return }
         loadingUnvalidatedHTTPSPage = false


### PR DESCRIPTION
Issues fixed in this PR:

#341 - pressing reload on a loaded site blocked b/c of potential phishing leaves an empty page 
#342 - Blocked page (phishing alert) should stop a BraveWebView from continuing processing 
#343 -  Blocked page (via phishing block) should return a result page within response to webview 
#336 - App hangs when toggling Block Phishing or shields up/down on certain sites. 