### PR TITLE
Bookmark edit fixes

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -9,4 +9,5 @@ github "drmohundro/SWXMLHash"       "2.1.0"
 github "DaveWoodCom/XCGLogger"      "Version_3.5.1"        # Previously: swift_1.2
 github "fluffyemily/SwiftKeychainWrapper" "extension-compatibility"					# default to latest tag
 github "mixpanel/mixpanel-iphone"  "v3.0.3"
+github "xmartlabs/Eureka" "1.7.0"
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,6 @@
 github "Alamofire/Alamofire" "2.0.2"
 github "mozilla/Deferred" "2.0.1"
+github "xmartlabs/Eureka" "1.7.0"
 github "swisspol/GCDWebServer" "3.3.2"
 github "kif-framework/KIF" "v3.3.2"
 github "rs/SDWebImage" "3.8.2"

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -3448,7 +3448,8 @@
 				"$(SRCROOT)/Carthage/Build/iOS/OnePasswordExtension.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Deferred.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftKeychainWrapper.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/MixPanel.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Eureka.framework",
+                "$(SRCROOT)/Carthage/Build/iOS/MixPanel.framework",
 			);
 			name = "Copy Carthage Dependencies";
 			outputPaths = (

--- a/Client.xcodeproj/xcshareddata/xcschemes/Brave.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Brave.xcscheme
@@ -56,6 +56,26 @@
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2FCAE2231ABB51F800877008"
+               BuildableName = "StorageTests.xctest"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4D567211ADECE2700F1EFE7"
+               BuildableName = "ReadingListTests.xctest"
+               BlueprintName = "ReadingListTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Client.xcodeproj/xcshareddata/xcschemes/BraveShareTo.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/BraveShareTo.xcscheme
@@ -43,13 +43,33 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2FCAE2231ABB51F800877008"
+               BuildableName = "StorageTests.xctest"
+               BlueprintName = "StorageTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4D567211ADECE2700F1EFE7"
+               BuildableName = "ReadingListTests.xctest"
+               BlueprintName = "ReadingListTests"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EB0F42501C9A46D800676650"
-            BuildableName = "BraveShareTo.appex"
-            BlueprintName = "BraveShareTo"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
             ReferencedContainer = "container:Client.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -457,11 +457,10 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         }
     }
     
+   
     func disableTableEditingMode() {
         dispatch_async(dispatch_get_main_queue()) {
-            if self.tableView.editing {
-                self.switchTableEditingMode()
-            }
+            self.switchTableEditingMode(true)
         }
     }
     
@@ -469,7 +468,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         return orderedBookmarkGUIDs != orderUpdatedBookmarkGUIDs
     }
     
-    func switchTableEditingMode() {
+    func switchTableEditingMode(forceOff:Bool = false) {
         //check if the table has been reordered, if so make the changes persistent
         if self.tableView.editing && bookmarksOrderChanged {
             orderedBookmarkGUIDs = orderUpdatedBookmarkGUIDs
@@ -489,11 +488,19 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         }
         
         dispatch_async(dispatch_get_main_queue()) {
-            self.tableView.setEditing(!self.tableView.editing, animated: true)
-            self.updateAddRemoveFolderButton()
-            self.editBookmarksButton.title = self.tableView.editing ? NSLocalizedString("Done", comment: "Done") : NSLocalizedString("Edit", comment: "Edit")
-            self.editBookmarksButton.style = self.tableView.editing ? .Done : .Plain
+
+            let editMode:Bool = forceOff ? false : !self.tableView.editing
+            self.tableView.setEditing(editMode, animated: forceOff ? false : true)
+            //only when the 'edit' button has been pressed
+            self.updateAddRemoveFolderButton(editMode)
+            self.updateEditBookmarksButton(editMode)
         }
+    }
+    
+    func updateEditBookmarksButton(tableIsEditing:Bool) {
+        self.editBookmarksButton.title = tableIsEditing ? NSLocalizedString("Done", comment: "Done") : NSLocalizedString("Edit", comment: "Edit")
+        self.editBookmarksButton.style = tableIsEditing ? .Done : .Plain
+
     }
     
     /*
@@ -503,9 +510,9 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
      * the button disappears when not in edit mode in both cases. When a subfolder is not empty,
      * pressing the remove folder button will show an error message explaining why (suboptimal, but allows to expose this functionality)
      */
-    func updateAddRemoveFolderButton() {
+    func updateAddRemoveFolderButton(tableIsEditing:Bool) {
         
-        if !tableView.editing {
+        if !tableIsEditing {
             addRemoveFolderButton.enabled = false
             addRemoveFolderButton.title = nil
             return
@@ -543,7 +550,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         addRemoveFolderButton = UIBarButtonItem()
         items.append(addRemoveFolderButton)
 
-        updateAddRemoveFolderButton()
+        updateAddRemoveFolderButton(false)
         
         items.append(UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: self, action: nil))
 

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -287,7 +287,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         }
         
         tableView.snp_makeConstraints { make in
-            make.bottom.equalTo(view).inset(UIEdgeInsetsMake(0, 0, toolbarHeight, 0))
+            make.bottom.equalTo(self.view).inset(UIEdgeInsetsMake(0, 0, toolbarHeight, 0))
             return
         }
         

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -272,7 +272,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
     init() {
         super.init(nibName: nil, bundle: nil)
-        self.title = "Bookmarks"
+        self.title = NSLocalizedString("Bookmarks", comment: "title for bookmarks panel")
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(BookmarksPanel.notificationReceived(_:)), name: NotificationFirefoxAccountChanged, object: nil)
 
         self.tableView.registerClass(SeparatorTableCell.self, forCellReuseIdentifier: BookmarkSeparatorCellIdentifier)

--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -6,6 +6,7 @@ import UIKit
 import Storage
 import Shared
 import XCGLogger
+import Eureka
 
 private let log = Logger.browserLogger
 
@@ -52,49 +53,6 @@ public extension UIBarButtonItem {
     }
 }
 
-@objc class BookmarkFoldersPickerDataSource : NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
-    var folders:[BookmarkFolder] = [BookmarkFolder]()
-    var componentWidth:CGFloat = 300
-    var rowHeight:CGFloat = 60
-    
-    override init() {
-        
-    }
-    
-    func addFolder(folder:BookmarkFolder) {
-        folders.append(folder)
-    }
-    
-    func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
-        return 1
-    }
-    func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return folders.count
-    }
-    
-    func pickerView(pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
-        return componentWidth
-    }
-    
-    func pickerView(pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
-        return 18
-    }
-    
-    func pickerView(pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusingView view: UIView?) -> UIView {
-        var rowView:UILabel! = view as? UILabel
-        if rowView == nil {
-            rowView = UILabel()
-            rowView.font = UIFont.systemFontOfSize(13)
-            rowView.text = folders[row].title
-        }
-        return rowView
-    }
-    
-    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return folders[row].title
-    }
-}
-
 class BkPopoverControllerDelegate : NSObject, UIPopoverPresentationControllerDelegate {
     func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
         return .None;
@@ -136,233 +94,128 @@ class BorderedButton: UIButton {
     }
 }
 
-class BookmarkEditViewController : UIViewController {
-    var completionBlock:(() -> Void)?
-    var sourceTable:UITableView!
-    var sourceCell:UITableViewCell!
-    var folderPickerDataSource:BookmarkFoldersPickerDataSource!
-    var nameTextField:UITextField!
-    var urlValue:UITextField!
-    var folderPicker:UIPickerView!
-    var okButton:UIButton!
-    var cancelButton:UIButton!
 
-    var dialogHeight:CGFloat = 200
+class BookmarkEditingViewController: FormViewController {
+    var completionBlock:((controller:BookmarkEditingViewController) -> Void)?
+    var sourceTable:UITableView!
+    
+    var folders:[BookmarkFolder]!
     
     var bookmarksPanel:BookmarksPanel!
     var bookmark:BookmarkItem!
     var currentFolderGUID:String!
     var bookmarkIndexPath:NSIndexPath!
     
-    init(sourceTable table:UITableView!, sourceCell cell:UITableViewCell!, indexPath:NSIndexPath, currentFolderGUID:String, bookmarksPanel:BookmarksPanel, bookmark:BookmarkItem!, folderPickerDataSource:BookmarkFoldersPickerDataSource) {
+    let BOOKMARK_TITLE_ROW_TAG:String = "BOOKMARK_TITLE_ROW_TAG"
+    let BOOKMARK_URL_ROW_TAG:String = "BOOKMARK_URL_ROW_TAG"
+    let BOOKMARK_FOLDER_ROW_TAG:String = "BOOKMARK_FOLDER_ROW_TAG"
+
+    var originalTitle:String!
+    var originalFolderGUID:String!
+
+    var titleRow:TextRow!
+    var urlRow:LabelRow!
+    var folderSelectionRow:PickerInlineRow<BookmarkFolder>!
+    
+    init(sourceTable table:UITableView!, indexPath:NSIndexPath, currentFolderGUID:String, bookmarksPanel:BookmarksPanel, bookmark:BookmarkItem!, folders:[BookmarkFolder]) {
         super.init(nibName: nil, bundle: nil)
         sourceTable = table
-        sourceCell = cell
         
-        let targetWidth = sourceTable.bounds.width * 0.8
-        
-        if UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone {
-            self.modalPresentationStyle = .OverCurrentContext //.Popover
-            self.modalTransitionStyle = .CoverVertical
-            self.preferredContentSize = UIScreen.mainScreen().bounds.size
-        }
-        else {
-            self.modalPresentationStyle = .Popover
-            self.preferredContentSize = CGSize(width: targetWidth, height: dialogHeight)
-            self.popoverPresentationController!.delegate = BkPopoverControllerDelegate()
-        }
-    
-        self.folderPickerDataSource = folderPickerDataSource
+        self.folders = folders
         self.bookmark = bookmark
         self.bookmarksPanel = bookmarksPanel
         self.bookmarkIndexPath = indexPath
         self.currentFolderGUID = currentFolderGUID
+        
+        self.originalTitle = self.bookmark.title
+        self.originalFolderGUID = currentFolderGUID
     }
     
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
-    
-    func folderDataForGUID(guid:String) -> (guid:String, title:String, position:Int)? {
-        var position = 0
-        for item in folderPickerDataSource.folders {
-            if item.guid == guid {
-                return (guid: item.guid, title:item.title, position: position)
-            }
-            position += 1
+
+    override func viewWillDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        //called when we're about to be popped, so use this for callback
+        if let block = self.completionBlock {
+            block(controller: self)
         }
-        return nil
+    }
+
+    var newFolderGUID:String! {
+        let selectedGUID = folderSelectionRow.value?.guid
+        
+        if selectedGUID == originalFolderGUID {
+            return nil
+        }
+        
+        return selectedGUID
+    }
+
+    var newTitle:String! {
+        guard let possibleNewTitle = titleRow.value else {
+            return nil
+        }
+        
+        let newTitle:String! = possibleNewTitle.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        
+        if newTitle.characters.count == 0 || newTitle == originalTitle {
+            return nil
+        }
+        return newTitle
+    }
+
+    var bookmarkTitleChanged:Bool {
+        return self.newTitle != nil
+    }
+
+    var bookmarkFolderChanged:Bool {
+        return self.newFolderGUID != nil
+    }
+
+    var bookmarkDataChanged:Bool {
+        return bookmarkTitleChanged || bookmarkFolderChanged
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onTap)))
         
-        let targetWidth = sourceTable.bounds.width * 0.8
-
-        let dataContainer = UIView()
-        
-        let mainView = UIView()
-        mainView.frame = CGRect(x: 0, y: 0, width: targetWidth, height: dialogHeight)
-        mainView.layer.cornerRadius = 8
-        mainView.layer.masksToBounds = true
-
-        if UIDevice.currentDevice().userInterfaceIdiom == UIUserInterfaceIdiom.Phone {
-            var point = view.center
-            //iPhone correction for the border - TODO calculate based on table
-            point.x = point.x - 20
-            mainView.center = view.center
-            dataContainer.frame = CGRect(x: 0, y: 0, width: targetWidth, height: dialogHeight-40)
-        }
-        else {
-            dataContainer.frame = CGRect(x: 10, y: 0, width: targetWidth-20, height: dialogHeight-40)
-        }
-        
-        let dataWidth = dataContainer.frame.size.width
-        mainView.backgroundColor = UIColor(white: 1, alpha: 0.98)
-        mainView.opaque = true
-        
-        dataContainer.backgroundColor = UIColor.clearColor()
-        mainView.addSubview(dataContainer)
-        view.addSubview(mainView)
-        view.backgroundColor =  UIColor(white: 0.2, alpha: 0.8)
-        
-        mainView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(onTap)))
-
-        if let popover = self.popoverPresentationController {
-            popover.permittedArrowDirections = .Any
-            popover.sourceView = sourceCell
-            popover.sourceRect = sourceCell.bounds
-            popover.popoverLayoutMargins = UIEdgeInsetsMake(0, 0, 0, 0)
-        }
-        
-        let margin:CGFloat = 10
-        let labelWidth:CGFloat = 50
-        let rowHeight:CGFloat = 20
-//        let textFieldWidth = CGFloat(targetWidth) - CGFloat(margin*2) - CGFloat(5) - labelWidth
-        
-        let nameLabel:UILabel = UILabel()
-        nameLabel.font = UIFont.boldSystemFontOfSize(13)
-        nameLabel.textColor = UIColor.blackColor()
-        nameLabel.text = "Edit Bookmark"
-        nameLabel.frame = CGRect(x: 0, y: margin, width: dataWidth, height: rowHeight)
-        nameLabel.textAlignment = NSTextAlignment.Center
-        
-        
-        let textLabel:UILabel = UILabel()
-        textLabel.font = UIFont.boldSystemFontOfSize(10)
-        textLabel.text = "Title"
-        textLabel.textColor = UIColor.grayColor()
-        textLabel.frame = CGRect(x: 10, y: 2, width: 40, height: 15)
-
-        
-        nameTextField = UITextField()
-        nameTextField.backgroundColor = UIColor.whiteColor()
-        nameTextField.layer.borderWidth = 0.5
-        nameTextField.layer.borderColor = UIColor.lightGrayColor().CGColor
-        nameTextField.font = UIFont.systemFontOfSize(13)
-
-        nameTextField.leftViewMode = .Always
-        nameTextField.leftView = textLabel
-        nameTextField.clearButtonMode = .WhileEditing
-        
-        nameTextField.frame = CGRect(x: 0, y: 40, width: dataWidth, height: rowHeight)
-        nameTextField.text = bookmark.title
-        
-        let urlLabel:UILabel = UILabel()
-        urlLabel.font = UIFont.boldSystemFontOfSize(10)
-        urlLabel.text = "URL"
-        urlLabel.textColor = UIColor.lightGrayColor()
-        urlLabel.frame = CGRect(x: 10, y: 2, width: 40, height: 15)
-
-        urlValue = UITextField()
-        urlValue.font = UIFont.systemFontOfSize(11)
-        urlValue.leftViewMode = .Always
-        urlValue.leftView = urlLabel
-        urlValue.textColor = UIColor.grayColor()
-        urlValue.frame = CGRect(x: 0, y: 60, width: dataWidth, height: rowHeight)
-        urlValue.text = bookmark.url
-        
-        let folderLabel:UILabel = UILabel()
-        folderLabel.font = UIFont.boldSystemFontOfSize(10)
-        folderLabel.text = "Folder"
-        folderLabel.textColor = UIColor.grayColor()
-        folderLabel.frame = CGRect(x: 0, y: (margin*3)+(rowHeight*2)+10, width: labelWidth, height: rowHeight)
-        folderPicker = UIPickerView()
-        
-        folderPicker.frame = CGRect(x: 0, y: (margin*3)+(rowHeight*2)+20, width: dataWidth, height: 60)
-//        folderPicker.frame = CGRect(x: margin*2, y: (margin*4)+(rowHeight*3), width: targetWidth*0.8, height: 60)
-
-        self.folderPickerDataSource.componentWidth = targetWidth*0.8
-        folderPicker.dataSource = self.folderPickerDataSource
-        folderPicker.delegate = self.folderPickerDataSource
-        
-        if let data = folderDataForGUID(currentFolderGUID) {
-            folderPicker.selectRow(data.position, inComponent: 0, animated: true)
-        }
-        
-        dataContainer.addSubview(nameLabel)
-        dataContainer.addSubview(nameTextField)
-        dataContainer.addSubview(urlValue)
-        dataContainer.addSubview(folderLabel)
-        dataContainer.addSubview(folderPicker)
-        
-        let middle:CGFloat = targetWidth/2
-        
-        
-        okButton = BorderedButton(type: .System)
-        okButton.setTitle("OK", forState: .Normal)
-        okButton.frame = CGRect(x: middle, y: dialogHeight-39, width: middle, height: 40)
-        okButton.addTarget(self, action: #selector(onOkPressed), forControlEvents: .TouchUpInside)
-        
-        cancelButton = BorderedButton(type: .System)
-        cancelButton.tintColor = UIColor.darkGrayColor()
-        cancelButton.frame = CGRect(x: -1, y: dialogHeight-39, width: middle+1, height: 40)
-        cancelButton.setTitle("Cancel", forState: .Normal)
-        cancelButton.addTarget(self, action: #selector(onCancelPressed), forControlEvents: .TouchUpInside)
-
-        mainView.addSubview(okButton)
-        mainView.addSubview(cancelButton)
-    }
-    
-    func onOkPressed() {
-        //save & dismiss
-        if let possibleNewTitle = nameTextField.text  {
-            var newTitle:String! = possibleNewTitle.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-            let folderGUID = folderPickerDataSource.folders[folderPicker.selectedRowInComponent(0)].guid as String
-            
-            let newFolderGUID:String? = (folderGUID == currentFolderGUID) ? nil : folderGUID
-
-            if newTitle.characters.count == 0 {
-                //TODO error
-                return
+        form +++ Section(NSLocalizedString("Bookmark Info", comment: "Bookmark Info Section Title"))
+            <<< TextRow() { row in
+                row.tag = BOOKMARK_TITLE_ROW_TAG
+                row.title = NSLocalizedString("Name", comment: "Bookmark name/title")
+                row.value = bookmark.title
+                self.titleRow = row
             }
-            
-            if newTitle == bookmark.title && newFolderGUID == nil {
-                //nothing to change in this case
-                return
+            <<< LabelRow() { row in
+                row.tag = BOOKMARK_URL_ROW_TAG
+                row.title = NSLocalizedString("URL", comment: "Bookmark URL")
+                row.value = bookmark.url
+                self.urlRow = row
             }
-            newTitle = (newTitle == bookmark.title) ? nil : newTitle
-            
-            bookmarksPanel.editBookmark(bookmark, newTitle: newTitle, newFolderGUID: newFolderGUID, atIndexPath: bookmarkIndexPath)
-            NSNotificationCenter.defaultCenter().postNotificationName(BookmarkStatusChangedNotification, object: bookmark, userInfo:["added": false])
+            +++ Section(NSLocalizedString("Location", comment: "Bookmark folder location"))
+            <<< PickerInlineRow<BookmarkFolder>() { (row : PickerInlineRow<BookmarkFolder>) -> Void in
+                row.tag = BOOKMARK_FOLDER_ROW_TAG
+                row.title = NSLocalizedString("Folder", comment: "Folder")
+                row.displayValueFor = { (rowValue: BookmarkFolder?) in
+                    return (rowValue?.title) ?? ""
+                }
+                let foldersArray = self.folders
+                row.options = foldersArray
+                
+                var currentFolder:BookmarkFolder!
+                for i in 0..<foldersArray.count {
+                    let folder = foldersArray[i]
+                    if self.currentFolderGUID == folder.guid {
+                        currentFolder = folder
+                        break
+                    }
+                }
+                row.value = currentFolder
+                self.folderSelectionRow = row
         }
-        self.dismiss()
-    }
-
-    func onCancelPressed() {
-        //dismiss
-        self.dismiss()
-    }
-    
-    func onTap(recognizer: UITapGestureRecognizer) {
-        if recognizer.view == self.view {
-            self.dismiss()
-        }
-    }
-    
-    func dismiss() {
-        self.dismissViewControllerAnimated(true, completion: completionBlock)
+        
     }
 }
 
@@ -377,7 +230,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             }
         }
     }
-    var folderPicker:BookmarkFoldersPickerDataSource!
+    var folderList:[BookmarkFolder] = [BookmarkFolder]()
     
     var currentItemCount:Int {
         return source?.current.count ?? 0
@@ -395,6 +248,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     var addRemoveFolderButton:UIBarButtonItem!
     var removeFolderButton:UIBarButtonItem!
     var addFolderButton:UIBarButtonItem!
+    
+    var isEditingInvidivualBookmark:Bool = false
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -416,7 +271,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+                
         let width = self.view.bounds.size.width
         let toolbarHeight = CGFloat(44)
         editBookmarksToolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: width, height: toolbarHeight))
@@ -457,7 +312,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         }
     }
     
-   
     func disableTableEditingMode() {
         dispatch_async(dispatch_get_main_queue()) {
             self.switchTableEditingMode(true)
@@ -506,7 +360,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     /*
      * Subfolders can only be added to the root folder, and only subfolders can be deleted/removed, so we use
      * this button (on the left side of the bookmarks toolbar) for both functions depending on where we are.
-     * Therefore when we enter edit mode on the root we show 'new folder' 
+     * Therefore when we enter edit mode on the root we show 'new folder'
      * the button disappears when not in edit mode in both cases. When a subfolder is not empty,
      * pressing the remove folder button will show an error message explaining why (suboptimal, but allows to expose this functionality)
      */
@@ -539,7 +393,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         
         items.append(UIBarButtonItem.createFixedSpaceItem(5))
 
-        //these two buttons are created as placeholders for the data/actions in each case. see #updateAddRemoveFolderButton and 
+        //these two buttons are created as placeholders for the data/actions in each case. see #updateAddRemoveFolderButton and
         //#switchTableEditingMode
         addFolderButton = UIBarButtonItem(title: NSLocalizedString("New Folder", comment: "New Folder"),
                                           style: .Plain, target: self, action: #selector(onAddBookmarksFolderButton))
@@ -553,7 +407,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         updateAddRemoveFolderButton(false)
         
         items.append(UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: self, action: nil))
-
 
         editBookmarksButton = UIBarButtonItem(title: NSLocalizedString("Edit", comment: "Edit"),
                                               style: .Plain, target: self, action: #selector(onEditBookmarksButton))
@@ -579,26 +432,24 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
         alert.addAction(UIAlertAction(title: okButtonTitle, style: okButtonType,
-                                        handler: { (alertA: UIAlertAction!) in
-                                            if canDeleteFolder {
-                                                
-                                                self.profile.bookmarks.modelFactory >>== {
-                                                    $0.removeByGUID(folderGUID).uponQueue(dispatch_get_main_queue()) { res in
-                                                        if res.isSuccess {
-                                                            self.navigationController?.popViewControllerAnimated(true)
-                                                            self.currentBookmarksPanel().reloadData()
-                                                        }
-                                                    }
-                                                }
-
-                                                
-                                            }
-                                        }))
+            handler: { (alertA: UIAlertAction!) in
+                if canDeleteFolder {
+                    
+                    self.profile.bookmarks.modelFactory >>== {
+                        $0.removeByGUID(folderGUID).uponQueue(dispatch_get_main_queue()) { res in
+                            if res.isSuccess {
+                                self.navigationController?.popViewControllerAnimated(true)
+                                self.currentBookmarksPanel().reloadData()
+                            }
+                        }
+                    }
+                }
+        }))
         if canDeleteFolder {
             alert.addAction(UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel,
                 handler: nil))
-            }
-            self.presentViewController(alert, animated: true) {
+        }
+        self.presentViewController(alert, animated: true) {
         }
     }
     
@@ -607,17 +458,17 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         let alert = UIAlertController(title: "New Folder", message: "Enter folder name", preferredStyle: UIAlertControllerStyle.Alert)
 
         let okAction = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default) { (alertA: UIAlertAction!) in
-                                                                                            self.addFolder(alertA, alertController:alert)
-                                                                                        }
+            self.addFolder(alertA, alertController:alert)
+        }
         let cancelAction = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel, handler: nil)
         
         alert.addAction(okAction)
         alert.addAction(cancelAction)
-    
+
         alert.addTextFieldWithConfigurationHandler({(textField: UITextField!) in
-                    textField.placeholder = "<folder name>"
-                    textField.secureTextEntry = false
-                })
+            textField.placeholder = "<folder name>"
+            textField.secureTextEntry = false
+        })
         
         self.presentViewController(alert, animated: true) {}
     }
@@ -676,19 +527,17 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             let newCount = self.currentItemCount
             
             if self.bookmarkFolder == nil { //we're on root, load folders into picker
-                self.folderPicker = BookmarkFoldersPickerDataSource()
+                self.folderList = [BookmarkFolder]()
             }
             self.orderedBookmarkGUIDs.removeAll()
             
-
-
             let rootFolder = MemoryBookmarkFolder(guid: BookmarkRoots.MobileFolderGUID, title: "Root Folder", children: [])
-            self.folderPicker.addFolder(rootFolder)
+            self.folderList.append(rootFolder)
             for i in 0..<newCount {
                 if let item = self.source!.current[i] {
                     self.orderedBookmarkGUIDs.append(item.guid)
                     if let f = item as? BookmarkFolder {
-                        self.folderPicker.addFolder(f)
+                        self.folderList.append(f)
                     }
                 }
             }
@@ -793,6 +642,10 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         return super.tableView(tableView, hasFullWidthSeparatorForRowAtIndexPath: indexPath)
     }
     
+    func tableView(tableView: UITableView, willSelectRowAtIndexPath indexPath: NSIndexPath) -> NSIndexPath? {
+        return indexPath
+    }
+    
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
         guard let source = source else {
@@ -803,8 +656,14 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
 
         switch (bookmark) {
         case let item as BookmarkItem:
-            if let url = NSURL(string: item.url) {
-                homePanelDelegate?.homePanel(self, didSelectURL: url, visitType: VisitType.Bookmark)
+            if tableView.editing {
+                //show editing view for bookmark item
+                self.showEditBookmarkController(tableView, indexPath: indexPath)
+            }
+            else {
+                if let url = NSURL(string: item.url) {
+                    homePanelDelegate?.homePanel(self, didSelectURL: url, visitType: VisitType.Bookmark)
+                }
             }
             break
 
@@ -813,7 +672,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             let nextController = BookmarksPanel()
             nextController.parentFolders = parentFolders + [source.current]
             nextController.bookmarkFolder = folder
-            nextController.folderPicker = self.folderPicker
+            nextController.folderList = self.folderList
             nextController.homePanelDelegate = self.homePanelDelegate
             nextController.profile = self.profile
             source.modelFactory.uponQueue(dispatch_get_main_queue()) { maybe in
@@ -905,7 +764,7 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         })
         
         
-        let rename = UITableViewRowAction(style: UITableViewRowActionStyle.Normal, title: editTitle, handler: { (action, indexPath) in
+        let edit = UITableViewRowAction(style: UITableViewRowActionStyle.Normal, title: editTitle, handler: { (action, indexPath) in
             guard let bookmark = source.current[indexPath.row] else {
                 return
             }
@@ -913,21 +772,43 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
             if bookmark is BookmarkFolder {
                 return
             }
-            let currentFolderGUID = self.bookmarkFolder?.guid ?? BookmarkRoots.MobileFolderGUID
-            let cell = self.tableView(self.tableView, cellForRowAtIndexPath: indexPath)
-            let vc: BookmarkEditViewController = BookmarkEditViewController(sourceTable:self.tableView, sourceCell: cell, indexPath: indexPath, currentFolderGUID:currentFolderGUID, bookmarksPanel: self, bookmark: bookmark as! BookmarkItem, folderPickerDataSource: self.folderPicker)
-            self.modalPresentationStyle = .CurrentContext
-           
-            postAsyncToMain {
-                self.presentViewController(vc, animated: true) {}
-            }
+            
+            self.showEditBookmarkController(tableView, indexPath: indexPath)
         })
 
-        return [delete, rename]
+        return [delete, edit]
+    }
+    
+    func showEditBookmarkController(tableView: UITableView, indexPath:NSIndexPath) {
+        guard let source = source else {
+            return
+        }
+
+        guard let bookmark = source.current[indexPath.row] else {
+            return
+        }
+
+        let currentFolderGUID = self.bookmarkFolder?.guid ?? BookmarkRoots.MobileFolderGUID
+
+        let nextController = BookmarkEditingViewController(sourceTable:self.tableView,indexPath: indexPath, currentFolderGUID:currentFolderGUID, bookmarksPanel: self, bookmark: bookmark as! BookmarkItem, folders: self.folderList)
+
+        nextController.completionBlock = {(controller: BookmarkEditingViewController) -> Void in
+            self.isEditingInvidivualBookmark = false
+            if controller.bookmarkDataChanged {
+                postAsyncToBackground {
+                    self.updateBookmarkData(bookmark, newTitle: controller.newTitle, newFolderGUID: controller.newFolderGUID, atIndexPath: controller.bookmarkIndexPath)
+                    NSNotificationCenter.defaultCenter().postNotificationName(BookmarkStatusChangedNotification, object: bookmark, userInfo:["added": false])
+                }
+            }
+        }
+        self.isEditingInvidivualBookmark = true
+
+        postAsyncToMain {
+            self.navigationController?.pushViewController(nextController, animated: true)
+        }
     }
 
-    
-    func editBookmark(bookmark:BookmarkNode, newTitle:String?, newFolderGUID: String?, atIndexPath indexPath: NSIndexPath) {
+    func updateBookmarkData(bookmark:BookmarkNode, newTitle:String?, newFolderGUID: String?, atIndexPath indexPath: NSIndexPath) {
         postAsyncToBackground {
             if let sqllitbk = self.profile.bookmarks as? MergedSQLiteBookmarks {
                 if newFolderGUID == nil { //rename only
@@ -950,7 +831,6 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
                             self.reloadData()
                         }
                     }
-
                 }
             }
         }

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -78,6 +78,13 @@ class TwoLineTableViewCell: UITableViewCell {
 
 class HistoryTableViewCell: TwoLineTableViewCell {
     let borderView = UIView()
+    //TODO improve this fix for label width when in editing mode (visible in bookmarks panel)
+    var labelCellWidthDefault:CGFloat = 0 {
+        didSet {
+            labelCellWidthEditMode = labelCellWidthDefault - 80
+        }
+    }
+    var labelCellWidthEditMode:CGFloat = 0
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: UITableViewCellStyle.Subtitle, reuseIdentifier: reuseIdentifier)
@@ -91,6 +98,8 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         twoLineHelper.hasBorderView = true
 
         twoLineHelper.setUpViews(self, textLabel: textLabel!, detailTextLabel: detailTextLabel!, imageView: imageView!)
+        self.labelCellWidthDefault = textLabel!.frame.width
+
     }
 
     override func layoutSubviews() {
@@ -98,11 +107,39 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         twoLineHelper.layoutSubviews()
 
         imageView!.center = borderView.center
+
+        if let frame:CGRect = self.textLabel?.frame {
+            self.labelCellWidthDefault = frame.width
+        }
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         separatorInset = UIEdgeInsetsMake(0, TwoLineCellUX.BorderFrameSize + 2 * TwoLineCellUX.BorderViewMargin, 0, 0)
+        if let frame:CGRect = self.textLabel?.frame {
+            labelCellWidthDefault = frame.width
+        }
+    }
+    
+    override func didTransitionToState(state: UITableViewCellStateMask) {
+        super.didTransitionToState(state)
+        if let frame:CGRect = self.textLabel?.frame {
+            if state.contains(.ShowingEditControlMask) && self.editing {
+                UIView.animateWithDuration(0.1) {
+                    self.textLabel?.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: self.labelCellWidthEditMode, height: frame.size.height)
+                }
+
+            }
+            else if state == .DefaultMask {
+                UIView.animateWithDuration(0.1) {
+                    self.textLabel?.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: self.labelCellWidthDefault, height: frame.size.height)
+                }
+                
+            }
+            else if state == .ShowingDeleteConfirmationMask {
+                
+            }
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -85,6 +85,7 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         }
     }
     var labelCellWidthEditMode:CGFloat = 0
+    var labelCellWidthOnLayout:CGFloat = 0
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: UITableViewCellStyle.Subtitle, reuseIdentifier: reuseIdentifier)
@@ -110,6 +111,7 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         if let frame:CGRect = self.textLabel?.frame {
             if frame.width > 0 {
                 self.labelCellWidthDefault = frame.width
+                labelCellWidthOnLayout = self.labelCellWidthDefault
             }
         }
     }
@@ -118,6 +120,9 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         super.prepareForReuse()
         editingState = false
         separatorInset = UIEdgeInsetsMake(0, TwoLineCellUX.BorderFrameSize + 2 * TwoLineCellUX.BorderViewMargin, 0, 0)
+        //restore label width
+        labelCellWidthDefault = labelCellWidthOnLayout
+        updateTextLabelWidthForEditing(editingState)
     }
     
     func updateTextLabelWidthForEditing(editingMode:Bool) {

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -111,7 +111,7 @@ class HistoryTableViewCell: TwoLineTableViewCell {
             self.labelCellWidthDefault = frame.width
         }
 
-        updateTextLabelWidthForEditing(editingState)
+//        updateTextLabelWidthForEditing(editingState)
     }
 
     override func prepareForReuse() {
@@ -134,9 +134,9 @@ class HistoryTableViewCell: TwoLineTableViewCell {
     }
     var editingState:Bool = false
 
-    override func didTransitionToState(state: UITableViewCellStateMask) {
-        super.didTransitionToState(state)
-        if state.contains(.ShowingEditControlMask) && self.editing {
+    override func willTransitionToState(state: UITableViewCellStateMask) {
+        super.willTransitionToState(state)
+        if state.contains(.ShowingEditControlMask) {
             editingState = true
         }
         else if state == .DefaultMask {
@@ -145,8 +145,8 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         else if state == .ShowingDeleteConfirmationMask {
             editingState = false
         }
+        self.twoLineHelper.blockLabelLayout = editingState
         updateTextLabelWidthForEditing(editingState)
-
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -255,6 +255,9 @@ private class TwoLineCellHelper {
     var imageView: UIImageView!
     var hasBorderView: Bool = false
     var hasRightBadge: Bool = false
+    
+    //flag used when the table goes temporarily into edit mode and we need to handle label sizes independently
+    var blockLabelLayout:Bool = false
 
     // TODO: Not ideal. We should figure out a better way to get this initialized.
     func setUpViews(container: UIView, textLabel: UILabel, detailTextLabel: UILabel, imageView: UIImageView) {
@@ -286,16 +289,19 @@ private class TwoLineCellHelper {
         let textLeft = hasBorderView ? TwoLineCellUX.BorderFrameSize + 2 * TwoLineCellUX.BorderViewMargin : TwoLineCellUX.ImageSize + 2 * TwoLineCellUX.BorderViewMargin
         let textLabelHeight = textLabel.intrinsicContentSize().height
         let detailTextLabelHeight = detailTextLabel.intrinsicContentSize().height
-        var contentHeight = textLabelHeight
-        if detailTextLabelHeight > 0 {
-            contentHeight += detailTextLabelHeight + TwoLineCellUX.DetailTextTopMargin
-        }
-
         let textRightInset: CGFloat = hasRightBadge ? (TwoLineCellUX.BadgeSize + TwoLineCellUX.BadgeMargin) : 0
+        
+        if !blockLabelLayout {
+            var contentHeight = textLabelHeight
+            if detailTextLabelHeight > 0 {
+                contentHeight += detailTextLabelHeight + TwoLineCellUX.DetailTextTopMargin
+            }
 
+            textLabel.frame = CGRectMake(textLeft, (height - contentHeight) / 2,
+                                         container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, textLabelHeight)
+        }
+        
         imageView.frame = CGRectMake(TwoLineCellUX.BorderViewMargin, (height - TwoLineCellUX.ImageSize) / 2, TwoLineCellUX.ImageSize, TwoLineCellUX.ImageSize)
-        textLabel.frame = CGRectMake(textLeft, (height - contentHeight) / 2,
-            container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, textLabelHeight)
         detailTextLabel.frame = CGRectMake(textLeft, textLabel.frame.maxY + TwoLineCellUX.DetailTextTopMargin,
             container.frame.width - textLeft - TwoLineCellUX.BorderViewMargin - textRightInset, detailTextLabelHeight)
     }

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -108,20 +108,16 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         imageView!.center = borderView.center
 
         if let frame:CGRect = self.textLabel?.frame {
-            self.labelCellWidthDefault = frame.width
+            if frame.width > 0 {
+                self.labelCellWidthDefault = frame.width
+            }
         }
-
-//        updateTextLabelWidthForEditing(editingState)
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         editingState = false
         separatorInset = UIEdgeInsetsMake(0, TwoLineCellUX.BorderFrameSize + 2 * TwoLineCellUX.BorderViewMargin, 0, 0)
-        if let frame:CGRect = self.textLabel?.frame {
-            labelCellWidthDefault = frame.width
-        }
-        
     }
     
     func updateTextLabelWidthForEditing(editingMode:Bool) {

--- a/Client/Frontend/Widgets/TwoLineCell.swift
+++ b/Client/Frontend/Widgets/TwoLineCell.swift
@@ -99,7 +99,6 @@ class HistoryTableViewCell: TwoLineTableViewCell {
 
         twoLineHelper.setUpViews(self, textLabel: textLabel!, detailTextLabel: detailTextLabel!, imageView: imageView!)
         self.labelCellWidthDefault = textLabel!.frame.width
-
     }
 
     override func layoutSubviews() {
@@ -111,35 +110,43 @@ class HistoryTableViewCell: TwoLineTableViewCell {
         if let frame:CGRect = self.textLabel?.frame {
             self.labelCellWidthDefault = frame.width
         }
+
+        updateTextLabelWidthForEditing(editingState)
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        editingState = false
         separatorInset = UIEdgeInsetsMake(0, TwoLineCellUX.BorderFrameSize + 2 * TwoLineCellUX.BorderViewMargin, 0, 0)
         if let frame:CGRect = self.textLabel?.frame {
             labelCellWidthDefault = frame.width
         }
+        
     }
     
-    override func didTransitionToState(state: UITableViewCellStateMask) {
-        super.didTransitionToState(state)
+    func updateTextLabelWidthForEditing(editingMode:Bool) {
         if let frame:CGRect = self.textLabel?.frame {
-            if state.contains(.ShowingEditControlMask) && self.editing {
-                UIView.animateWithDuration(0.1) {
-                    self.textLabel?.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: self.labelCellWidthEditMode, height: frame.size.height)
-                }
-
-            }
-            else if state == .DefaultMask {
-                UIView.animateWithDuration(0.1) {
-                    self.textLabel?.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: self.labelCellWidthDefault, height: frame.size.height)
-                }
-                
-            }
-            else if state == .ShowingDeleteConfirmationMask {
-                
+            let newWidth:CGFloat = editingMode ? labelCellWidthEditMode : labelCellWidthDefault
+            UIView.animateWithDuration(0.1) {
+                self.textLabel?.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: newWidth, height: frame.size.height)
             }
         }
+    }
+    var editingState:Bool = false
+
+    override func didTransitionToState(state: UITableViewCellStateMask) {
+        super.didTransitionToState(state)
+        if state.contains(.ShowingEditControlMask) && self.editing {
+            editingState = true
+        }
+        else if state == .DefaultMask {
+            editingState = false
+        }
+        else if state == .ShowingDeleteConfirmationMask {
+            editingState = false
+        }
+        updateTextLabelWidthForEditing(editingState)
+
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ build Brave scheme
 
 #### Note: building your own ad-hoc builds is supported [see user device build](brave/docs/USER-DEPLOYING.md)
 
+
 ## Crash reporting using Fabric
 
 To enable, add ~/.brave-fabric-keys with 2 lines, the API key and build secret. Re-run setup.sh and the project will be generated to use Fabric and Crashlytics frameworks.
@@ -40,6 +41,17 @@ Run Product>Test in Xcode to do so. Not all Firefox tests are passing yet.
 Most of the code is in the brave/ directory. The primary design goal has been to preserve easy merging from Firefox iOS upstream, so hopefully code changes outside of that dir are minimal.
 
 To find changes outside of brave/, look for #if BRAVE / #if !BRAVE (#if/#else/#endif is supported by Swift).
+
+## Adding Carthage modules
+
+1. Add line into Cartfile
+2. Run `carthage update` (there may be errors on first run, ignore)
+3. Verify that your new module has been added to Cartfile.resolved
+4. Run `checkout.sh`
+5. In the Xcode Project, go to Client target settings, open the `Build Phases` tab and add a line such as
+```
+$(SRCROOT)/Carthage/Build/iOS/FRAMEWORKNAME.framework
+```
 
 ## Provisioning Profiles using a Team account
 

--- a/Storage/Bookmarks/BookmarksModel.swift
+++ b/Storage/Bookmarks/BookmarksModel.swift
@@ -9,7 +9,7 @@ import Shared
 /**
  * The kinda-immutable base interface for bookmarks and folders.
  */
-public class BookmarkNode {
+public class BookmarkNode : Equatable {
     public var id: Int? = nil
     public let guid: GUID
     public var title: String
@@ -25,6 +25,10 @@ public class BookmarkNode {
     public var canDelete: Bool {
         return self.isEditable
     }
+}
+
+public func==(lhs:BookmarkNode, rhs:BookmarkNode) -> Bool {
+    return lhs.guid == rhs.guid
 }
 
 public class BookmarkSeparator: BookmarkNode {

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -454,32 +454,18 @@ public class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
         }
     }
     
-    public func editBookmark(bookmark:BookmarkNode, newTitle:String?, newParentID:String?, completion:dispatch_block_t)  {
-        if newTitle == nil && newParentID == nil {
-            //just return
-            completion()
-            return
-        }
+    public func editBookmark(bookmark:BookmarkNode, title:String, parentGUID:String, completion:dispatch_block_t)  {
         
-        var updateQuery = "UPDATE \(TableBookmarksLocal) "
-        if newTitle != nil && newParentID != nil {
-            updateQuery += " set title='\(newTitle!)', parentid='\(newParentID!)' "
-        }
-        else if newTitle != nil {
-            updateQuery += " set title='\(newTitle!)' "
-        }
-        else {
-            updateQuery += " set parentid='\(newParentID!)' "
-        }
-        
-        updateQuery +=  " where guid='\(bookmark.guid)"
+        let updateQuery = "UPDATE \(TableBookmarksLocal) "
+                                + "set title='\(title)', parentid='\(parentGUID)' "
+                                +  "where guid='\(bookmark.guid)'"
         
         let structureArgs = Args()
         var err: NSError?
 
         self.db.transaction(&err) { (conn, err) -> Bool in
             //TODO moving a bookmark to another folder seems to be failing
-            if !self.change(conn, sql: updateQuery, args: structureArgs, desc: "Error updating item \(bookmark.guid) to new title \(newTitle).") {
+            if !self.change(conn, sql: updateQuery, args: structureArgs, desc: "Error updating item \(bookmark.guid) to title=[\(title)] parentGUID=[\(parentGUID)].") {
                 return false
             }
             
@@ -701,8 +687,8 @@ extension MergedSQLiteBookmarks: BookmarkBufferStorage {
         return self.buffer.applyRecords(records)
     }
 
-    public func editBookmark(bookmark:BookmarkNode, newTitle:String?, newParentID: String? = nil, completion:dispatch_block_t)  {
-        self.buffer.editBookmark(bookmark, newTitle:newTitle, newParentID:newParentID, completion:completion)
+    public func editBookmark(bookmark:BookmarkNode, title:String, parentGUID: String, completion:dispatch_block_t)  {
+        self.buffer.editBookmark(bookmark, title:title, parentGUID:parentGUID, completion:completion)
     }
     
     public func reorderBookmarks(folderGUID:String, bookmarksOrder:[String], completion:dispatch_block_t)  {

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -463,16 +463,16 @@ public class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
         
         var updateQuery = "UPDATE \(TableBookmarksLocal) "
         if newTitle != nil && newParentID != nil {
-            updateQuery += " set title='\(newTitle)', parentid='\(newParentID)' "
+            updateQuery += " set title='\(newTitle!)', parentid='\(newParentID!)' "
         }
         else if newTitle != nil {
-            updateQuery += " set title='\(newTitle)' "
+            updateQuery += " set title='\(newTitle!)' "
         }
         else {
-            updateQuery += " set parentid='\(newParentID)' "
+            updateQuery += " set parentid='\(newParentID!)' "
         }
         
-        updateQuery +=  " where guid='\(bookmark.guid)'"
+        updateQuery +=  " where guid='\(bookmark.guid)"
         
         let structureArgs = Args()
         var err: NSError?

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -908,7 +908,9 @@ extension SQLiteBookmarkBufferStorage {
         }.allSucceed()
 
         deferred.upon { success in
-            notificationCenter.postNotificationName(NotificationBookmarkBufferValidated, object: Box(validations))
+            dispatch_async(dispatch_get_main_queue()) {
+                notificationCenter.postNotificationName(NotificationBookmarkBufferValidated, object: Box(validations))
+            }
         }
 
         return deferred

--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -453,8 +453,29 @@ public class SQLiteBookmarkBufferStorage: BookmarkBufferStorage {
             return success
         }
     }
+
+    public func editBookmarkFolder(folder:BookmarkFolder, title:String, completion:dispatch_block_t)  {
+        
+        let updateQuery = "UPDATE '\(TableBookmarksLocal)' "
+            + "set title='\(title)' "
+            +  "where guid='\(folder.guid)'"
+        
+        let structureArgs = Args()
+        var err: NSError?
+        
+        self.db.transaction(&err) { (conn, err) -> Bool in
+            
+            if !self.change(conn, sql: updateQuery, args: structureArgs, desc: "Error updating item \(folder.guid) to title=[\(title)].") {
+                return false
+            }
+            
+            completion()
+            return true
+        }
+    }
+
     
-    public func editBookmark(bookmark:BookmarkNode, title:String, parentGUID:String, completion:dispatch_block_t)  {
+    public func editBookmarkItem(bookmark:BookmarkNode, title:String, parentGUID:String, completion:dispatch_block_t)  {
         
         let updateQuery = "UPDATE '\(TableBookmarksLocal)' "
                                 + "set title='\(title)', parentid='\(parentGUID)' "
@@ -697,8 +718,12 @@ extension MergedSQLiteBookmarks: BookmarkBufferStorage {
         return self.buffer.applyRecords(records)
     }
 
-    public func editBookmark(bookmark:BookmarkNode, title:String, parentGUID: String, completion:dispatch_block_t)  {
-        self.buffer.editBookmark(bookmark, title:title, parentGUID:parentGUID, completion:completion)
+    public func editBookmarkFolder(bookmark:BookmarkFolder, title:String, completion:dispatch_block_t)  {
+        self.buffer.editBookmarkFolder(bookmark, title:title, completion:completion)
+    }
+
+    public func editBookmarkItem(bookmark:BookmarkItem, title:String, parentGUID: String, completion:dispatch_block_t)  {
+        self.buffer.editBookmarkItem(bookmark, title:title, parentGUID:parentGUID, completion:completion)
     }
     
     public func reorderBookmarks(folderGUID:String, bookmarksOrder:[String], completion:dispatch_block_t)  {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -177,7 +177,9 @@ extension SQLiteHistory: BrowserHistory {
             // Insert instead.
             let j = self.insertSite(site, atTime: now, withConnection: conn)
             if j > 0 {
-                NSNotificationCenter.defaultCenter().postNotificationName(kNotificationSiteAddedToHistory, object: nil)
+                dispatch_async(dispatch_get_main_queue()) {
+                    NSNotificationCenter.defaultCenter().postNotificationName(kNotificationSiteAddedToHistory, object: nil)
+                }
             }
             return j
         }


### PR DESCRIPTION
This set of changes fixes the various issues associated with editing by using a simpler/more 'standard' interface, ie., copying Safari's in-table form for editing bookmarks. 