### PR TITLE
Improvements for 'Settings > Report a Bug'

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -15,7 +15,7 @@ private let Bug1204635_S3 = NSLocalizedString("Clear", tableName: "ClearPrivateD
 private let Bug1204635_S4 = NSLocalizedString("Cancel", tableName: "ClearPrivateData", comment: "Used as a button label in the dialog to cancel clear private data dialog")
 
 // A base setting class that shows a title. You probably want to subclass this, not use it directly.
-class Setting {
+class Setting : NSObject {
     private var _title: NSAttributedString?
 
     weak var delegate: SettingsDelegate?

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -309,7 +309,6 @@ class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
     }
 
     override func onClick(navigationController: UINavigationController?) {
-        
         //MFMailComposeViewController is wonky on simulator, detect & avoid
         let isDevice = (TARGET_OS_SIMULATOR == 0)
         
@@ -325,14 +324,18 @@ class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
             mailComposerVC.setToRecipients([reportBugMailAddress])
             mailComposerVC.setSubject(reportBugMailSubject)
             
+            let iOSVersionLabel = NSLocalizedString("iOS version", comment: "iOS version")
+            let deviceLabel = NSLocalizedString("Device", comment: "Device")
+            let braveVersionLabel = NSLocalizedString("Brave version", comment: "brave version")
+            
             let appVersionString: String = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
             let buildNumber: String = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as! String
             let versionAndBuildNumber: String = "\(appVersionString) (\(buildNumber))"
             
             var message = reportBugMailBody
-            message += "iOS version: [\(UIDevice.currentDevice().systemName)/\(UIDevice.currentDevice().systemVersion)]\n"
-            message += "Device: [\(UIDevice.currentDevice().name)/\(UIDevice.currentDevice().model)]\n"
-            message += "Brave version: [\(versionAndBuildNumber)]\n"
+            message += "\(iOSVersionLabel) [\(UIDevice.currentDevice().systemName)/\(UIDevice.currentDevice().systemVersion)]\n"
+            message += "\(deviceLabel): [\(UIDevice.currentDevice().name)/\(UIDevice.currentDevice().model)]\n"
+            message += "\(braveVersionLabel): [\(versionAndBuildNumber)]\n"
             message += "-----------------------------\n"
             mailComposerVC.setMessageBody(message, isHTML: false)
             

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -4,6 +4,7 @@
     import Crashlytics
 #endif
 import Shared
+import MessageUI
 
 let kPrefKeyNoScriptOn = "noscript_on"
 let kPrefKeyFingerprintProtection = "fingerprintprotection_on"
@@ -126,7 +127,7 @@ class BraveSettingsView : AppSettingsTableViewController {
         settings += [
             SettingSection(title: NSAttributedString(string: NSLocalizedString("Support", comment: "Support section title")), children: [
                 ShowIntroductionSetting(settings: self),
-                BraveSupportLinkSetting(),
+                BraveSupportLinkSetting(parentVC: self),
                 BravePrivacyPolicySetting(), BraveTermsOfUseSetting(),
                 ])]
         //#endif
@@ -277,14 +278,73 @@ class PasswordsClearable: Clearable {
     }
 }
 
-class BraveSupportLinkSetting: Setting{
+class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
+    let parentViewController:UIViewController
+    
+    init(parentVC:UIViewController) {
+        parentViewController = parentVC
+    }
+
     override var title: NSAttributedString? {
         return NSAttributedString(string: NSLocalizedString("Report a bug", comment: "Show mail composer to report a bug."), attributes: [NSForegroundColorAttributeName: UIConstants.TableViewRowTextColor])
     }
-
+    
+    func mailComposeController(controller: MFMailComposeViewController, didFinishWithResult result: MFMailComposeResult, error: NSError?) {
+        
+        controller.dismissViewControllerAnimated(true) {
+            if result == MFMailComposeResultSaved || result == MFMailComposeResultSent {
+                postAsyncToMain {
+                    //only show 'thanks' dialog when Saved/Sent. 
+                    //TODO turn this into a Toast-type notification that goes away by itself.
+                    let sendFeedbackThanks = UIAlertView(title: "Thanks!", message: "Thank you for your feedback!", delegate: self, cancelButtonTitle: "OK")
+                    sendFeedbackThanks.show()
+                }
+            }
+            else if result == MFMailComposeResultFailed {
+                postAsyncToMain {
+                    self.showMailErrorDialog()
+                }
+            }
+        }
+    }
 
     override func onClick(navigationController: UINavigationController?) {
-        UIApplication.sharedApplication().openURL(NSURL(string: "mailto:support+ios@brave.com")!)
+        
+        //MFMailComposeViewController is wonky on simulator, detect & avoid
+        let isDevice = (TARGET_OS_SIMULATOR == 0)
+        
+        if MFMailComposeViewController.canSendMail() && isDevice {
+            
+            let reportBugMailAddress = "support+ios@brave.com"
+            let reportBugMailSubject = NSLocalizedString("Brave for iOS Feedback", comment: "email subject")
+            let reportBugMailBody = "\n\n\n--------------------\nPlease do not modify the information that follows.\nIt is completely anonymous and necessary for the Brave Team to evaluate reports, issues and bugs. Thanks!\n-----------------------------\n";
+
+            
+            let mailComposerVC = MFMailComposeViewController()
+            mailComposerVC.mailComposeDelegate = self
+            mailComposerVC.setToRecipients([reportBugMailAddress])
+            mailComposerVC.setSubject(reportBugMailSubject)
+            
+            let appVersionString: String = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as! String
+            let buildNumber: String = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as! String
+            let versionAndBuildNumber: String = "\(appVersionString) (\(buildNumber))"
+            
+            var message = reportBugMailBody
+            message += "iOS version: [\(UIDevice.currentDevice().systemName)/\(UIDevice.currentDevice().systemVersion)]\n"
+            message += "Device: [\(UIDevice.currentDevice().name)/\(UIDevice.currentDevice().model)]\n"
+            message += "Brave version: [\(versionAndBuildNumber)]\n"
+            message += "-----------------------------\n"
+            mailComposerVC.setMessageBody(message, isHTML: false)
+            
+            parentViewController.presentViewController(mailComposerVC, animated: true, completion: nil)
+        } else {
+            showMailErrorDialog()
+        }
+    }
+    
+    func showMailErrorDialog() {
+        let sendMailErrorAlert = UIAlertView(title: "Error sending email", message: "It appears you're not setup for email on this device.  Please check your email configuration and try again.", delegate: self, cancelButtonTitle: "OK")
+        sendMailErrorAlert.show()
     }
 
     override func onConfigureCell(cell: UITableViewCell) {

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -316,7 +316,7 @@ class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
             
             let reportBugMailAddress = "support+ios@brave.com"
             let reportBugMailSubject = NSLocalizedString("Brave for iOS Feedback", comment: "email subject")
-            let reportBugMailBody = "\n\n\n--------------------\nPlease do not modify the information that follows.\nIt is completely anonymous and necessary for the Brave Team to evaluate reports, issues and bugs. Thanks!\n-----------------------------\n";
+            let reportBugMailBody = NSLocalizedString("\n\n---\nApp & Device Version Information:\n", comment: "body");
 
             
             let mailComposerVC = MFMailComposeViewController()

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -297,8 +297,7 @@ class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
                 //TODO turn this into a Toast-type notification that goes away by itself.
                 let sendFeedbackThanks = UIAlertView(title: "Thanks!", message: "Thank you for your feedback!", delegate: self, cancelButtonTitle: "OK")
                 sendFeedbackThanks.show()
-            }
-            else if result == MFMailComposeResultFailed {
+            } else if result == MFMailComposeResultFailed {
                 self.showMailErrorDialog()
             }
         }

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -293,17 +293,13 @@ class BraveSupportLinkSetting: Setting, MFMailComposeViewControllerDelegate {
         
         controller.dismissViewControllerAnimated(true) {
             if result == MFMailComposeResultSaved || result == MFMailComposeResultSent {
-                postAsyncToMain {
-                    //only show 'thanks' dialog when Saved/Sent. 
-                    //TODO turn this into a Toast-type notification that goes away by itself.
-                    let sendFeedbackThanks = UIAlertView(title: "Thanks!", message: "Thank you for your feedback!", delegate: self, cancelButtonTitle: "OK")
-                    sendFeedbackThanks.show()
-                }
+                //only show 'thanks' dialog when Saved/Sent.
+                //TODO turn this into a Toast-type notification that goes away by itself.
+                let sendFeedbackThanks = UIAlertView(title: "Thanks!", message: "Thank you for your feedback!", delegate: self, cancelButtonTitle: "OK")
+                sendFeedbackThanks.show()
             }
             else if result == MFMailComposeResultFailed {
-                postAsyncToMain {
-                    self.showMailErrorDialog()
-                }
+                self.showMailErrorDialog()
             }
         }
     }


### PR DESCRIPTION
Fixed #406 - ‘report a bug' (in settings) no response to button if there's no email account configured

Fixed #331 - Improvement for Settings > Report a Bug 