### PR TITLE
Fix development team setting in xcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,12 +74,10 @@ MozBuildID.xcconfig
 Carthage/Build
 
 node_modules/
-build-id.xcconfig
 ABPFilterParserData.dat
 Client/Configuration
 Client/Info.plist
-/brave/xcconfig/.local-def.xcconfig
-/brave/xcconfig/.bundle-id.xcconfig
+/brave/xcconfig/local-def.xcconfig
 /brave/Brave.entitlements
 /brave/BraveInfo.plist
 .fabric-key-setup.sh

--- a/brave/Brave.entitlements.template
+++ b/brave/Brave.entitlements.template
@@ -4,11 +4,11 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.BUNDLE_ID_PLACEHOLDER</string>
+		<string>APPGROUP_PLACEHOLDER</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>KL8N8XSYF4.BUNDLE_ID_PLACEHOLDER</string>
+		<string>KEYCHAIN_PLACEHOLDER</string>
 	</array>
 </dict>
 </plist>

--- a/brave/setup.sh
+++ b/brave/setup.sh
@@ -5,22 +5,30 @@
 app_id=${1:-`whoami`.brave}
 echo Using APPID of $app_id, you can customize using ./setup.sh org.foo.myapp
 
-echo CUSTOM_BUNDLE_ID=$app_id > xcconfig/.bundle-id.xcconfig
+echo CUSTOM_BUNDLE_ID=$app_id > xcconfig/local-def.xcconfig
 # Custom IDs get the BETA property set automatically
-[[ $app_id != com.brave.ios.browser ]] && echo BETA=Beta >> xcconfig/.bundle-id.xcconfig
+[[ $app_id != com.brave.ios.browser ]] && echo BETA=Beta >> xcconfig/local-def.xcconfig
+
+sed -e "s/APPGROUP_PLACEHOLDER/group.$app_id/" Brave.entitlements.template > Brave.entitlements
+
 # if a brave build, setup fabric and mixpanel
 if [[ $app_id == com.brave.ios.browser* ]]; then
+    dev_team_id="KL8N8XSYF4"
+    sed -i '' -e "s/KEYCHAIN_PLACEHOLDER/$dev_team_id.$app_id/" Brave.entitlements
+    echo "DEVELOPMENT_TEAM=$dev_team_id" >> xcconfig/local-def.xcconfig
     echo adding fabric
     echo "./Fabric.framework/run $(head -1 ~/.brave-fabric-keys) $(tail -1 ~/.brave-fabric-keys)" > build-system/.fabric-key-setup.sh
-    
-  sed -e s/FABRIC_KEY_REMOVED/$(head -1 ~/.brave-fabric-keys)/  BraveInfo.plist.template | sed -e s/MIXPANEL_TOKEN_REMOVED/$(head -1 ~/.brave-mixpanel-key)/ > BraveInfo.plist
+    sed -e s/FABRIC_KEY_REMOVED/$(head -1 ~/.brave-fabric-keys)/  BraveInfo.plist.template | sed -e s/MIXPANEL_TOKEN_REMOVED/$(head -1 ~/.brave-mixpanel-key)/ > BraveInfo.plist
 else
-   >build-system/.fabric-key-setup.sh
-   cat BraveInfo.plist.template > BraveInfo.plist
+    sed -i '' -e "s/KEYCHAIN_PLACEHOLDER/\$\(AppIdentifierPrefix\)$app_id/" Brave.entitlements
+    >build-system/.fabric-key-setup.sh
+    cat BraveInfo.plist.template > BraveInfo.plist
+    echo "Please edit xcconfig/local-def.xcconfig to add your DEVELOPMENT_TEAM id (or else you will need to set this in Xcode)"
+    echo "  It is found here: https://developer.apple.com/account/#/membership"
+    echo "// DEVELOPMENT_TEAM=" >> xcconfig/local-def.xcconfig
 fi
 
-sed -e "s/BUNDLE_ID_PLACEHOLDER/$app_id/" Brave.entitlements.template > Brave.entitlements
+echo GENERATED_BUILD_ID=`date +"%y.%m.%d.%H"` >> xcconfig/local-def.xcconfig
 
 npm update
 
-echo GENERATED_BUILD_ID=`date +"%y.%m.%d.%H"`  > xcconfig/build-id.xcconfig

--- a/brave/xcconfig/BaseConfig.xcconfig
+++ b/brave/xcconfig/BaseConfig.xcconfig
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "./build-id.xcconfig"
-#include "./.bundle-id.xcconfig"
-#include "./.local-def.xcconfig"
+#include "./local-def.xcconfig"
 
 HEADER_SEARCH_PATHS = ./brave/ThirdParty/leveldb/include ./brave/ThirdParty/leveldb
 


### PR DESCRIPTION
Change to using a single local-def.xcconfig file. In this file, one can set their dev team.