### PR TITLE
Fix #549, Show FavIcon on all tabs, not just ones in memory

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -252,7 +252,8 @@ class Browser: NSObject, BrowserWebViewDelegate {
                     let forwardList = wv.backForwardList.forwardList ?? []
                     let urls = (backList + [currentItem] + forwardList).map { $0.URL }
                     let currentPage = -forwardList.count
-                    self.sessionData = SessionData(currentPage: currentPage, currentTitle: self.title, urls: urls, lastUsedTime: self.lastExecutedTime ?? NSDate.now())
+                    
+                    self.sessionData = SessionData(currentPage: currentPage, currentTitle: self.title, currentFavicon: self.displayFavicon, urls: urls, lastUsedTime: self.lastExecutedTime ?? NSDate.now())
                 }
             }
             self.browserDelegate?.browser(self, willDeleteWebView: wv)
@@ -323,7 +324,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
                 largest = icon.1
             }
         }
-        return largest
+        return largest ?? self.sessionData?.currentFavicon
     }
 
     var url: NSURL? {

--- a/Client/Frontend/Browser/SessionData.swift
+++ b/Client/Frontend/Browser/SessionData.swift
@@ -5,12 +5,14 @@
 import Foundation
 
 import Shared
+import Storage
 
 class SessionData: NSObject, NSCoding {
     let currentPage: Int
     let urls: [NSURL]
     let lastUsedTime: Timestamp
     var currentTitle: String = ""
+    var currentFavicon: Favicon?
 
     var jsonDictionary: [String: AnyObject] {
         return [
@@ -28,11 +30,12 @@ class SessionData: NSObject, NSCoding {
         - parameter urls:            The sequence of URLs in this tab's session history.
         - parameter lastUsedTime:    The last time this tab was modified.
     **/
-    init(currentPage: Int, currentTitle: String?, urls: [NSURL], lastUsedTime: Timestamp) {
+    init(currentPage: Int, currentTitle: String?, currentFavicon: Favicon?, urls: [NSURL], lastUsedTime: Timestamp) {
         self.currentPage = currentPage
         self.urls = urls
         self.lastUsedTime = lastUsedTime
         self.currentTitle = currentTitle ?? ""
+        self.currentFavicon = currentFavicon
 
         assert(urls.count > 0, "Session has at least one entry")
         assert(currentPage > -urls.count && currentPage <= 0, "Session index is valid")
@@ -43,6 +46,7 @@ class SessionData: NSObject, NSCoding {
         self.urls = coder.decodeObjectForKey("urls") as? [NSURL] ?? []
         self.lastUsedTime = UInt64(coder.decodeInt64ForKey("lastUsedTime")) ?? NSDate.now()
         self.currentTitle = coder.decodeObjectForKey("currentTitle") as? String ?? ""
+        self.currentFavicon = coder.decodeObjectForKey("currentFavicon") as? Favicon
     }
 
     func encodeWithCoder(coder: NSCoder) {
@@ -50,5 +54,6 @@ class SessionData: NSObject, NSCoding {
         coder.encodeObject(urls, forKey: "urls")
         coder.encodeInt64(Int64(lastUsedTime), forKey: "lastUsedTime")
         coder.encodeObject(currentTitle, forKey: "currentTitle")
+        coder.encodeObject(currentFavicon, forKey: "currentFavicon")
     }
 }

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -527,7 +527,7 @@ extension TabManager {
                 let forwardList = browser.webView?.backForwardList.forwardList ?? []
                 let urls = (backList + [currentItem] + forwardList).map { $0.URL }
                 let currentPage = -forwardList.count
-                self.sessionData = SessionData(currentPage: currentPage, currentTitle: browser.title, urls: urls, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
+                self.sessionData = SessionData(currentPage: currentPage, currentTitle: browser.title, currentFavicon: browser.displayFavicon, urls: urls, lastUsedTime: browser.lastExecutedTime ?? NSDate.now())
             } else {
                 self.sessionData = browser.sessionData
             }

--- a/Storage/Site.swift
+++ b/Storage/Site.swift
@@ -43,7 +43,7 @@ public enum IconType: Int {
     case NoneFound = 5
 }
 
-public class Favicon: Identifiable {
+public class Favicon: NSObject, Identifiable, NSCoding {
     public var id: Int? = nil
 
     public let url: String
@@ -56,6 +56,32 @@ public class Favicon: Identifiable {
         self.url = url
         self.date = date
         self.type = type
+    }
+    
+    required public init?(coder: NSCoder) {
+        self.id = Int(coder.decodeInt64ForKey("id"))
+        self.url = coder.decodeObjectForKey("url") as? String ?? ""
+        self.date = coder.decodeObjectForKey("date") as? NSDate ?? NSDate()
+        self.width = Int(coder.decodeInt64ForKey("width"))
+        self.height = Int(coder.decodeInt64ForKey("height"))
+        self.type = IconType(rawValue: Int(coder.decodeInt64ForKey("type"))) ?? .NoneFound
+    }
+    
+    public func encodeWithCoder(coder: NSCoder) {
+        if let id = id {
+            coder.encodeInt64(Int64(id), forKey: "id")
+        }
+        coder.encodeObject(url, forKey: "url")
+        coder.encodeObject(date, forKey: "date")
+        if let width = width {
+            coder.encodeInt64(Int64(width), forKey: "width")
+        }
+        
+        if let height = height {
+            coder.encodeInt64(Int64(height), forKey: "height")
+        }
+        
+        coder.encodeInt64(Int64(type.rawValue), forKey: "type")
     }
 }
 


### PR DESCRIPTION
Currently only the tabs in memory showed their favicons in the tab menu. This adds the current favicon to the session data and will fallback to the stored favicon if the webview has been removed from memory.

Since the favicon needs to be serialized, I added the NSCoding protocol to that class (making it an NSObject subclass). This approach seemed seemed to align best with the convention I saw.