### PR TITLE
Issue #277, added shields overview to brave panel when disabled

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -298,7 +298,8 @@ extension Strings {
     public static let Scripts_Blocked = NSLocalizedString("Scripts Blocked", comment: "individual blocking statistic title")
     public static let Fingerprinting_Methods = NSLocalizedString("Fingerprinting Methods", comment: "individual blocking statistic title")
     public static let Fingerprinting_Protection_wrapped = NSLocalizedString("Fingerprinting\nProtection", comment: "blocking stat title")
-
+    public static let Shields_Overview = NSLocalizedString("Site Shields allow you to control when ads and trackers are blocked for each site that you visit. If you prefer to see ads on a specific site, you can enable them here.", comment: "shields overview message")
+    public static let Shields_Overview_Footer = NSLocalizedString("Note: Some sites may require scripts to work properly so this shield is turned off by default.", comment: "shields overview footer message")
 }
 
 

--- a/brave/src/frontend/BraveTopViewController.swift
+++ b/brave/src/frontend/BraveTopViewController.swift
@@ -145,11 +145,7 @@ class BraveTopViewController : UIViewController {
         if !mainSidePanel.view.hidden {
             togglePanel(mainSidePanel)
         }
-
-        if self.browserViewController.tabManager.selectedTab?.displayURL?.absoluteString?.isEmpty ?? true {
-            return
-        }
-
+        
         browserViewController.tabManager.selectedTab?.webView?.checkScriptBlockedAndBroadcastStats()
         togglePanel(rightSidePanel)
     }

--- a/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
+++ b/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
@@ -15,10 +15,16 @@ class SidePanelBaseViewController : UIViewController {
 
     // Set false for a right side panel
     var isLeftSidePanel = true
+    
+    var isShowingOverview = false
 
     let shadow = UIImageView()
 
     var parentSideConstraints: [Constraint?]?
+    
+    func isShowingHome() -> Bool {
+        return getApp().browserViewController.homePanelController != nil
+    }
 
     override func loadView() {
         self.view = UIScrollView(frame: UIScreen.mainScreen().bounds)
@@ -68,7 +74,8 @@ class SidePanelBaseViewController : UIViewController {
                 if isLeftSidePanel {
                     make.right.top.equalTo(containerView)
                 } else {
-                    make.left.top.equalTo(view)
+                    make.left.equalTo(view)
+                    make.top.equalTo(view.superview!)
                 }
                 make.width.equalTo(BraveUX.PanelShadowWidth)
 
@@ -79,7 +86,9 @@ class SidePanelBaseViewController : UIViewController {
     }
 
     func setupConstraints() {
-        if shadow.image == nil { // arbitrary item check to see if func needs calling
+        if shadow.image == nil || // arbitrary item check to see if func needs calling
+            isShowingHome() && !isShowingOverview && !isLeftSidePanel ||
+            !isShowingHome() && isShowingOverview && !isLeftSidePanel {
             setupUIElements()
         }
     }
@@ -150,5 +159,6 @@ class SidePanelBaseViewController : UIViewController {
     func setHomePanelDelegate(delegate: HomePanelDelegate?) {}
 
 }
+
 
 


### PR DESCRIPTION
I added the shields overview to the brave panel when disabled. The panel uses a property named isShowingOverview and a function called isShowingHome() to determine the overview state. The state is based on the existence of the home panel controller. I used the existence of the home panel controller as the condition because that is what canShow was using.