### PR TITLE
Issue 600, right panel - separation of setting up the views, and updating them

### DIFF
--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -463,9 +463,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     }
     
     func toggleInteractionEnabled(enabled: Bool) {
-        for toggle: UISwitch in views_toggles {
-            toggle.enabled = enabled && !isShowingOverview
-        }
+        views_toggles.forEach { $0.on = enabled && !isShowingOverview }
     }
 
     func updateSitenameAndTogglesState() {
@@ -484,9 +482,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
             toggleBlockScripts.on = state?.isOnScriptBlocking() ?? (BraveApp.getPrefs()?.boolForKey(kPrefKeyNoScriptOn) ?? false)
             toggleBlockFingerprinting.on = state?.isOnFingerprintProtection() ?? (BraveApp.getPrefs()?.boolForKey(kPrefKeyFingerprintProtection) ?? false)
         } else {
-            for toggle: UISwitch in views_toggles {
-                toggle.on = false
-            }
+            views_toggles.forEach { $0.on = false }
         }
     }
 

--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -30,7 +30,8 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     let shieldsOverview = UILabel()
     let shieldsOverviewFooter = UILabel()
     
-    var headerContainerHeightConsraint: LayoutConstraint?
+    // Constraints stored for updating dynamically
+    var headerContainerHeightConstraint: LayoutConstraint?
     var siteNameContainerHeightConstraint: LayoutConstraint?
     var shieldsOverviewContainerHeightConstraint: LayoutConstraint?
 
@@ -155,7 +156,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
                 if i == 0 {
                     make.top.equalTo(section.superview!)
                     // Updated dynamically, setting to 0 just to setup height constraint
-                    headerContainerHeightConsraint = make.height.equalTo(0).constraint.layoutConstraints.first
+                    headerContainerHeightConstraint = make.height.equalTo(0).constraint.layoutConstraints.first
                 } else if section !== sections.last {
                     make.top.equalTo(sections[i - 1].snp_bottom)
                     make.bottom.equalTo(sections[i + 1].snp_top)
@@ -455,7 +456,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     
     func updateSitenameAndTogglesState() {
         let hostName = BraveApp.getCurrentWebView()?.URL?.normalizedHost() ?? "-"
-        // hostName will generally be "localhost" if home page is showing, so checking home page too
+        // hostName will generally be "localhost" if home page is showing, so checking home page
         siteName.text = isShowingShieldOverview() ? "" : hostName
 
         shieldToggle.enabled = !isShowingShieldOverview()
@@ -488,7 +489,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     }
     
     func updateConstraintsForPanelSections() {
-        headerContainerHeightConsraint?.constant = 44 + CGFloat(spaceForStatusBar())
+        headerContainerHeightConstraint?.constant = 44 + CGFloat(spaceForStatusBar())
         if isShowingShieldOverview() {
             siteNameContainerHeightConstraint?.constant = ui_siteNameSectionHeight - 30
             shieldsOverviewContainerHeightConstraint?.active = false

--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -30,6 +30,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     let shieldsOverview = UILabel()
     let shieldsOverviewFooter = UILabel()
     
+    var headerContainerHeightConsraint: LayoutConstraint?
     var siteNameContainerHeightConstraint: LayoutConstraint?
     var shieldsOverviewContainerHeightConstraint: LayoutConstraint?
 
@@ -153,17 +154,18 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
 
                 if i == 0 {
                     make.top.equalTo(section.superview!)
-                    make.height.equalTo(44 + spaceForStatusBar())
+                    // Updated dynamically, setting to 0 just to setup height constraint
+                    headerContainerHeightConsraint = make.height.equalTo(0).constraint.layoutConstraints.first
                 } else if section !== sections.last {
                     make.top.equalTo(sections[i - 1].snp_bottom)
                     make.bottom.equalTo(sections[i + 1].snp_top)
                 }
 
                 if section === siteNameContainer {
-                    // This will be updated dynamically, setting to 0 just to setup height constraint
+                    // Updated dynamically
                     siteNameContainerHeightConstraint = make.height.equalTo(0).constraint.layoutConstraints.first
                 } else if section === shieldsOverviewContainer {
-                    // This will also be updated dynamically
+                    // Updated dynamically
                     shieldsOverviewContainerHeightConstraint = make.height.equalTo(0).constraint.layoutConstraints.first
                 } else if section === statsContainer {
                     make.height.equalTo(isTinyScreen() ? 120 : 160)
@@ -489,16 +491,12 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
         super.showPanel(showing, parentSideConstraints: parentSideConstraints)
 
         if showing {
-            headerContainer.snp_remakeConstraints { make in
-                make.top.left.right.equalTo(headerContainer.superview!)
-                make.height.equalTo(44 + spaceForStatusBar())
-            }
             updateConstraintsForPanelSections()
-
         }
     }
     
     func updateConstraintsForPanelSections() {
+        headerContainerHeightConsraint?.constant = 44 + CGFloat(spaceForStatusBar())
         if isShowingShieldOverview() {
             siteNameContainerHeightConstraint?.constant = ui_siteNameSectionHeight - 30
             shieldsOverviewContainerHeightConstraint?.active = false

--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -454,9 +454,9 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     }
     
     func updateSitenameAndTogglesState() {
-        let hostName = BraveApp.getCurrentWebView()?.URL?.normalizedHost()
+        let hostName = BraveApp.getCurrentWebView()?.URL?.normalizedHost() ?? "-"
         // hostName will generally be "localhost" if home page is showing, so checking home page too
-        siteName.text = isShowingShieldOverview() || hostName == nil ? "" : hostName!
+        siteName.text = isShowingShieldOverview() ? "" : hostName
 
         shieldToggle.enabled = !isShowingShieldOverview()
         
@@ -501,6 +501,14 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     }
 
     func setShieldBlockedStats(shieldStats: ShieldBlockedStats) {
+        var shieldStats = shieldStats
+        // This check is placed here (instead of an update view method) because it can get called via external
+        //  sources, so safest to place right before assigning new text values
+        if isShowingShieldOverview() {
+            // HttpsUpgrade seems to be 1 for localhost, so overriding it
+            shieldStats = ShieldBlockedStats()
+        }
+        
         statAdsBlocked.text = String(shieldStats.abAndTp)
         statHttpsUpgrades.text = String(shieldStats.httpse)
         statFPBlocked.text = String(shieldStats.fp)

--- a/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
+++ b/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
@@ -58,6 +58,7 @@ class SidePanelBaseViewController : UIViewController {
         view.hidden = true
     }
 
+    /// This should just be called one time to initially setup the UI elements for the side panels
     func setupUIElements() {
         shadow.image = UIImage(named: "panel_shadow")
         shadow.contentMode = .ScaleToFill
@@ -86,9 +87,7 @@ class SidePanelBaseViewController : UIViewController {
     }
 
     func setupConstraints() {
-        if shadow.image == nil || // arbitrary item check to see if func needs calling
-            isShowingHome() && !isShowingOverview && !isLeftSidePanel ||
-            !isShowingHome() && isShowingOverview && !isLeftSidePanel {
+        if shadow.image == nil { // arbitrary item check to see if func needs calling
             setupUIElements()
         }
     }

--- a/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
+++ b/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
@@ -16,15 +16,9 @@ class SidePanelBaseViewController : UIViewController {
     // Set false for a right side panel
     var isLeftSidePanel = true
     
-    var isShowingOverview = false
-
     let shadow = UIImageView()
 
     var parentSideConstraints: [Constraint?]?
-    
-    func isShowingHome() -> Bool {
-        return getApp().browserViewController.homePanelController != nil
-    }
 
     override func loadView() {
         self.view = UIScrollView(frame: UIScreen.mainScreen().bounds)


### PR DESCRIPTION
The idea behind this PR is to separate the logic that used to initially construct the right panel, and the logic that needs to be adjusted dynamically (view size, button states, domain name label, and the new Shields Overview container's visibility).

On showing the right panel, constraints are now dynamically set. This keeps constraints clean, and prevents duplicate views from being added to the right-side panel.

I did notice there were lots of constraint errors on the logs (previously and currently present). These _seem_ to be failing correctly for _now_, but should probably be ironed out.