### PR TITLE
Global Shield Stats on Top Sites

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		5C32C7B6034B41A9C822555E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE1D74E40F9E392FFCE9F2F /* main.swift */; };
 		5C404E1B2531DC2E178F80F8 /* ReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8C87651157C51F01D4D96F /* ReaderPanel.swift */; };
 		5C67126F8B355442E99D9EDB /* BrowserViewController+FindInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA9175CB5140E6C4D47DC15 /* BrowserViewController+FindInPage.swift */; };
+		5CE70E451E022FAB008B307A /* BraveShieldStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE70E441E022FAB008B307A /* BraveShieldStatsView.swift */; };
+		5CE70E4D1E02831B008B307A /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE70E4C1E02831B008B307A /* IntExtensions.swift */; };
 		5CFC706D1D9D9F30008A7B7A /* BraveTermsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFC706C1D9D9F30008A7B7A /* BraveTermsViewController.swift */; };
 		5E5E76550DFB4EB71194132F /* LICENSE in Sources */ = {isa = PBXBuildFile; fileRef = 36C647DC00749BCC944D6EC6 /* LICENSE */; };
 		5E6571D452F3C000461D2481 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F94204C0EC007236424A86 /* AppDelegate.swift */; };
@@ -909,6 +911,8 @@
 		5B7417C2784852C8AA016A94 /* filename.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = filename.cc; path = ./brave/ThirdParty/leveldb/db/filename.cc; sourceTree = "<group>"; };
 		5B8A3FF8C10C5708D9DAD03D /* BraveUX.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BraveUX.swift; path = ./brave/src/frontend/BraveUX.swift; sourceTree = "<group>"; };
 		5C39A9721F0FECF98A48015E /* BraveBrowserViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BraveBrowserViewController.swift; path = ./brave/src/frontend/BraveBrowserViewController.swift; sourceTree = "<group>"; };
+		5CE70E441E022FAB008B307A /* BraveShieldStatsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BraveShieldStatsView.swift; path = brave/src/frontend/BraveShieldStatsView.swift; sourceTree = "<group>"; };
+		5CE70E4C1E02831B008B307A /* IntExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IntExtensions.swift; path = Utils/Extensions/IntExtensions.swift; sourceTree = "<group>"; };
 		5CFC706C1D9D9F30008A7B7A /* BraveTermsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BraveTermsViewController.swift; path = brave/src/frontend/BraveTermsViewController.swift; sourceTree = "<group>"; };
 		5D09BD4576555D874B5D0D4A /* db_impl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = db_impl.h; path = ./brave/ThirdParty/leveldb/db/db_impl.h; sourceTree = "<group>"; };
 		5D84AB2CBD701CBBDC40620C /* ReadingListAuthenticator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReadingListAuthenticator.swift; path = ./ReadingList/ReadingListAuthenticator.swift; sourceTree = "<group>"; };
@@ -1484,6 +1488,7 @@
 				430FDA25DAA3C35191998991 /* SwizzlingToHideSharePicker.h */,
 				84C51F13ADC0C2BC71D40BEF /* SwizzlingToHideSharePicker.m */,
 				3A6E86EA8E9535F4C6C7B748 /* tabsbar */,
+				5CE70E441E022FAB008B307A /* BraveShieldStatsView.swift */,
 			);
 			name = frontend;
 			sourceTree = "<group>";
@@ -2846,6 +2851,7 @@
 				2A6BFEC103054810F8925EAF /* UIColorExtensions.swift */,
 				286FDAED8C109239AF5BA1E4 /* UIImageExtensions.swift */,
 				4380F19554944742F9E55A9B /* UIViewExtensions.swift */,
+				5CE70E4C1E02831B008B307A /* IntExtensions.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -3722,6 +3728,7 @@
 				5FBB6E142EFF5F6E989ABD49 /* block_builder.cc in Sources */,
 				1204E92DCEECF3540EA648CF /* filter_block.cc in Sources */,
 				40DD8F2FF8733625CF906534 /* format.cc in Sources */,
+				5CE70E451E022FAB008B307A /* BraveShieldStatsView.swift in Sources */,
 				5F88581725B7AAA78F91A4D4 /* iterator.cc in Sources */,
 				3FE012C35D0AD5E2B5BB4767 /* merger.cc in Sources */,
 				479A31771C308868296EA8C3 /* table.cc in Sources */,
@@ -3774,6 +3781,7 @@
 				A1CFE166EBD926880A69E052 /* LoginsHelper+1PW.swift in Sources */,
 				907D2E87F3AB62A94DB2D9E7 /* InfoPlist.strings in Sources */,
 				CCCD5D311C1E3408F243DF5E /* ABPFilterLibWrapper.mm in Sources */,
+				5CE70E4D1E02831B008B307A /* IntExtensions.swift in Sources */,
 				3AAE8F176D74D5884854D830 /* AdBlocker.swift in Sources */,
 				EB9CAB431DC2592700627A39 /* UIWebViewSwizzling.m in Sources */,
 				A4997544E81DF456966522E6 /* BraveShieldState.swift in Sources */,
@@ -4061,6 +4069,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4088,6 +4097,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4118,6 +4128,7 @@
 		2FCAE2381ABB51F900877008 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -4189,6 +4200,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = brave/Brave.entitlements;
+				DEVELOPMENT_TEAM = "";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4228,6 +4240,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4278,6 +4291,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 5;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4332,6 +4346,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -4376,6 +4391,7 @@
 				CURRENT_PROJECT_VERSION = 5;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4426,6 +4442,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -4457,6 +4474,7 @@
 				CURRENT_PROJECT_VERSION = 5;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -4484,6 +4502,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -4503,6 +4522,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -4536,6 +4556,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -4562,6 +4583,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = BraveShareTo/BraveShareToInfo.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
@@ -4592,6 +4614,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -4620,6 +4643,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -4641,6 +4665,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = brave/tests_src/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -4656,6 +4681,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -4679,6 +4705,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -4697,6 +4724,7 @@
 		EB8E9B691C7CB4E1003AA90E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -4771,6 +4799,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = brave/Brave.entitlements;
+				DEVELOPMENT_TEAM = "";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -158,9 +158,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(application: UIApplication) {
         log.debug("Application will terminate.")
-
+        
         // We have only five seconds here, so let's hope this doesn't take too long.
         shutdownProfileWhenNotActive()
+        BraveGlobalShieldStats.singleton.save()
 
         // Allow deinitializers to close our database connections.
         self.profile = nil
@@ -317,8 +318,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(application: UIApplication) {
         print("Close database")
         shutdownProfileWhenNotActive()
+        BraveGlobalShieldStats.singleton.save()
     }
-
+    
     func applicationWillEnterForeground(application: UIApplication) {
         // The reason we need to call this method here instead of `applicationDidBecomeActive`
         // is that this method is only invoked whenever the application is entering the foreground where as 

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -95,11 +95,26 @@ class TopSitesPanel: UIViewController {
         collection.registerClass(ThumbnailCell.self, forCellWithReuseIdentifier: ThumbnailIdentifier)
         collection.keyboardDismissMode = .OnDrag
         collection.accessibilityIdentifier = "Top Sites View"
+        collection.contentInset = UIEdgeInsetsMake(120, 0, 0, 0)
         view.addSubview(collection)
         collection.snp_makeConstraints { make in
             make.edges.equalTo(self.view)
         }
         self.collection = collection
+        
+        let braveShieldStatsView = BraveShieldStatsView(frame: CGRectZero)
+        collection.addSubview(braveShieldStatsView)
+        
+        // Could setup as section header but would need to use flow layout,
+        // Auto-layout subview within collection doesn't work properly,
+        // Quick-and-dirty layout here.
+        var statsViewFrame: CGRect = braveShieldStatsView.frame
+        statsViewFrame.origin.x = 10
+        statsViewFrame.origin.y = -120
+        statsViewFrame.size.width = CGRectGetWidth(collection.frame) - CGRectGetMinX(statsViewFrame) * 2
+        statsViewFrame.size.height = 120
+        braveShieldStatsView.frame = statsViewFrame
+        braveShieldStatsView.autoresizingMask = [.FlexibleWidth]
 
         self.dataSource.collectionView = self.collection
         succeed().upon { _ in // move sync call off-main

--- a/Client/Frontend/Widgets/ThumbnailCell.swift
+++ b/Client/Frontend/Widgets/ThumbnailCell.swift
@@ -67,7 +67,7 @@ struct ThumbnailCellUX {
 
     static let LabelInsets = UIEdgeInsetsMake(0, 3, 2, 3)
     static let PlaceholderImage = UIImage(named: "defaultTopSiteIcon")
-    static let CornerRadius: CGFloat = 1.5
+    static let CornerRadius: CGFloat = 4
 
     // Make the remove button look 20x20 in size but have the clickable area be 44x44
     static let RemoveButtonSize: CGFloat = 44

--- a/Utils/Extensions/IntExtensions.swift
+++ b/Utils/Extensions/IntExtensions.swift
@@ -1,0 +1,40 @@
+//
+//  IntExtensions.swift
+//  Client
+//  http://stackoverflow.com/a/35504720/492366
+
+import Foundation
+
+extension Int {
+    func formatUsingAbbrevation () -> String {
+        let numFormatter = NSNumberFormatter()
+        
+        typealias Abbrevation = (threshold:Double, divisor:Double, suffix:String)
+        let abbreviations:[Abbrevation] = [(0, 1, ""),
+                                           (1000.0, 1000.0, "K"),
+                                           (100_000.0, 1_000_000.0, "M"),
+                                           (100_000_000.0, 1_000_000_000.0, "B")]
+        
+        let startValue = Double (abs(self))
+        let abbreviation:Abbrevation = {
+            var prevAbbreviation = abbreviations[0]
+            for tmpAbbreviation in abbreviations {
+                if (startValue < tmpAbbreviation.threshold) {
+                    break
+                }
+                prevAbbreviation = tmpAbbreviation
+            }
+            return prevAbbreviation
+        } ()
+        
+        let value = Double(self) / abbreviation.divisor
+        numFormatter.positiveSuffix = abbreviation.suffix
+        numFormatter.negativeSuffix = abbreviation.suffix
+        numFormatter.allowsFloats = true
+        numFormatter.minimumIntegerDigits = 1
+        numFormatter.minimumFractionDigits = 0
+        numFormatter.maximumFractionDigits = 1
+        
+        return numFormatter.stringFromNumber(NSNumber (double:value))!
+    }
+}

--- a/brave/src/frontend/BraveShieldStatsView.swift
+++ b/brave/src/frontend/BraveShieldStatsView.swift
@@ -1,0 +1,182 @@
+//
+//  BraveShieldStatsView.swift
+//  Client
+//
+
+import Foundation
+
+class BraveShieldStatsView: UIView {
+    private let millisecondsPerItem = 50
+    private let line = UIView()
+    
+    lazy var trackersStatView: StatView = {
+        let statView = StatView(frame: CGRectZero)
+        statView.title = "Ad/Trackers \rBlocked"
+        statView.color = UIColor(red: 234/255.0, green: 90/255.0, blue: 45/255.0, alpha: 1.0)
+        return statView
+    }()
+    
+    lazy var httpsStatView: StatView = {
+        let statView = StatView(frame: CGRectZero)
+        statView.title = "HTTPS \rUpgrades"
+        statView.color = UIColor(red: 242/255.0, green: 142/255.0, blue: 45/255.0, alpha: 1.0)
+        return statView
+    }()
+    
+    lazy var scriptsStatView: StatView = {
+        let statView = StatView(frame: CGRectZero)
+        statView.title = "Scripts \rBlocked"
+        statView.color = UIColor(red: 25/255.0, green: 152/255.0, blue: 252/255.0, alpha: 1.0)
+        return statView
+    }()
+    
+    lazy var timeStatView: StatView = {
+        let statView = StatView(frame: CGRectZero)
+        statView.title = "Est. Time \rSaved"
+        statView.color = UIColor(red: 14/255.0, green: 14/255.0, blue: 14/255.0, alpha: 1.0)
+        return statView
+    }()
+    
+    lazy var stats: [StatView] = {
+        return [self.trackersStatView, self.httpsStatView, self.scriptsStatView, self.timeStatView]
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(line)
+        line.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
+        line.snp_makeConstraints { (make) in
+            make.bottom.equalTo(0).offset(-0.5)
+            make.height.equalTo(0.5)
+            make.left.equalTo(0)
+            make.right.equalTo(0)
+        }
+        
+        for s: StatView in stats {
+            addSubview(s)
+        }
+        
+        update()
+        setNeedsLayout()
+        
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(update), name: BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+    }
+    
+    override func layoutSubviews() {
+        let width: CGFloat = frame.width / CGFloat(stats.count)
+        var offset: CGFloat = 0
+        for s: StatView in stats {
+            var f: CGRect = s.frame
+            f.origin.x = offset
+            f.size = CGSizeMake(width, frame.height)
+            s.frame = f
+            offset += width
+        }
+    }
+    
+    func update() {
+        trackersStatView.stat = BraveGlobalShieldStats.singleton.adblockAndTp.formatUsingAbbrevation()
+        httpsStatView.stat = BraveGlobalShieldStats.singleton.httpse.formatUsingAbbrevation()
+        scriptsStatView.stat = BraveGlobalShieldStats.singleton.noScript.formatUsingAbbrevation()
+        timeStatView.stat = timeSaved
+    }
+    
+    var timeSaved: String {
+        get {
+            let estimatedMillisecondsSaved = BraveGlobalShieldStats.singleton.adblockAndTp * millisecondsPerItem
+            let hours = estimatedMillisecondsSaved < 1000 * 60 * 60 * 24
+            let minutes = estimatedMillisecondsSaved < 1000 * 60 * 60
+            let seconds = estimatedMillisecondsSaved < 1000 * 60
+            var counter: Double = 0
+            var text = ""
+            
+            if seconds {
+                counter = ceil(Double(estimatedMillisecondsSaved / 1000))
+                text = "s"
+            }
+            else if minutes {
+                counter = ceil(Double(estimatedMillisecondsSaved / 1000 / 60))
+                text = "min"
+            }
+            else if hours {
+                counter = ceil(Double(estimatedMillisecondsSaved / 1000 / 60 / 60))
+                text = "h"
+            }
+            else {
+                counter = ceil(Double(estimatedMillisecondsSaved / 1000 / 60 / 60 / 24))
+                text = "d"
+            }
+            
+            return "\(Int(counter))\(text)"
+        }
+    }
+}
+
+class StatView: UIView {
+    var color: UIColor = UIColor.blackColor() {
+        didSet {
+            statLabel.textColor = color
+        }
+    }
+    
+    var stat: String = "" {
+        didSet {
+            statLabel.text = "\(stat)"
+        }
+    }
+    
+    var title: String = "" {
+        didSet {
+            titleLabel.text = "\(title)"
+        }
+    }
+    
+    private var statLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .Center
+        label.numberOfLines = 0
+        label.font = UIFont.systemFontOfSize(24, weight: UIFontWeightHeavy)
+        return label
+    }()
+    
+    private var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = BraveUX.TopSitesStatTitleColor
+        label.textAlignment = .Center
+        label.numberOfLines = 0
+        label.font = UIFont.systemFontOfSize(12, weight: UIFontWeightMedium)
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(statLabel)
+        addSubview(titleLabel)
+        
+        statLabel.snp_makeConstraints(closure: { (make) in
+            make.left.equalTo(0)
+            make.right.equalTo(0)
+            make.centerY.equalTo(self).offset(-(statLabel.sizeThatFits(CGSizeMake(CGFloat.max, CGFloat.max)).height)-10)
+        })
+        
+        titleLabel.snp_makeConstraints(closure: { (make) in
+            make.left.equalTo(0)
+            make.right.equalTo(0)
+            make.top.equalTo(statLabel.snp_bottom).offset(5)
+        })
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/brave/src/frontend/BraveUX.swift
+++ b/brave/src/frontend/BraveUX.swift
@@ -22,6 +22,8 @@ struct BraveUX {
     static let TabsBarPlusButtonWidth = (UIDevice.currentDevice().userInterfaceIdiom == .Pad) ? 40 : 0
     
     static let SwitchTintColor = UIColor(white: 0.8, alpha: 1.0)
+    
+    static let TopSitesStatTitleColor = UIColor(white: 0.6, alpha: 1.0)
 
     // I am considering using DeviceInfo.isBlurSupported() to set this, and reduce heavy animations
     static var IsHighLoadAnimationAllowed = true

--- a/brave/src/webfilters/BraveShieldState.swift
+++ b/brave/src/webfilters/BraveShieldState.swift
@@ -316,3 +316,75 @@ public struct BraveShieldState {
         setState(.FpProtection, on: pageState?.isOnFingerprintProtection() ?? (BraveApp.getPrefs()?.boolForKey(kPrefKeyFingerprintProtection) ?? false))
     }
 }
+
+public class BraveGlobalShieldStats {
+    static let singleton = BraveGlobalShieldStats()
+    static let DidUpdateNotification = "BraveGlobalShieldStatsDidUpdate"
+    
+    private let prefs = NSUserDefaults.standardUserDefaults()
+    
+    var adblockAndTp: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+    
+    var httpse: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+    
+    var safeBrowsing: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+    
+    var fpProtection: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+    
+    var noScript: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+    
+    enum Shield: String {
+        case AdblockAndTp = "adblock_and_tp"
+        case HTTPSE = "httpse"
+        case SafeBrowsing = "safebrowsing"
+        case FpProtection = "fp_protection"
+        case NoScript = "noscript"
+    }
+    
+    public init() {
+        adblockAndTp = adblockAndTp + prefs.integerForKey(Shield.AdblockAndTp.rawValue)
+        httpse = httpse + prefs.integerForKey(Shield.HTTPSE.rawValue)
+        safeBrowsing = safeBrowsing + prefs.integerForKey(Shield.SafeBrowsing.rawValue)
+        fpProtection = fpProtection + prefs.integerForKey(Shield.FpProtection.rawValue)
+        noScript = noScript + prefs.integerForKey(Shield.NoScript.rawValue)
+    }
+    
+    public func save() {
+        var task: UIBackgroundTaskIdentifier = UIBackgroundTaskIdentifier()
+        task = UIApplication.sharedApplication().beginBackgroundTaskWithName("brave-global-stats-save", expirationHandler: { () -> Void in
+            UIApplication.sharedApplication().endBackgroundTask(task)
+            task = UIBackgroundTaskInvalid
+        })
+        
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) { () -> Void in
+            self.prefs.setInteger(self.adblockAndTp, forKey: Shield.AdblockAndTp.rawValue)
+            self.prefs.setInteger(self.httpse, forKey: Shield.HTTPSE.rawValue)
+            self.prefs.setInteger(self.safeBrowsing, forKey: Shield.SafeBrowsing.rawValue)
+            self.prefs.setInteger(self.fpProtection, forKey: Shield.FpProtection.rawValue)
+            self.prefs.setInteger(self.noScript, forKey: Shield.NoScript.rawValue)
+            self.prefs.synchronize()
+            
+            task = UIBackgroundTaskInvalid
+        }
+    }
+}

--- a/brave/src/webview/BraveWebView.swift
+++ b/brave/src/webview/BraveWebView.swift
@@ -583,12 +583,16 @@ class BraveWebView: UIWebView {
             shieldStats = ShieldBlockedStats()
         case .httpseIncrement:
             shieldStats.httpse += value
+            BraveGlobalShieldStats.singleton.httpse += value
         case .abAndTpIncrement:
             shieldStats.abAndTp += value
+            BraveGlobalShieldStats.singleton.adblockAndTp += value
         case .jsSetValue:
             shieldStats.js = value
+            BraveGlobalShieldStats.singleton.noScript += value
         case .fpIncrement:
             shieldStats.fp += value
+            BraveGlobalShieldStats.singleton.fpProtection += value
         }
 
         postAsyncToMain(0.2) { [weak self] in


### PR DESCRIPTION
Global Shield Stats - Display Brave shield stats on top sites (new tab) screen.

1) Multiple tabs stats may be updated by observing changes on Global Stats Singleton.
2) Slight variation from initial design(laptop) that contained a separation between ads and trackers blocked. Those are not independently tracked, so it has been combined int one stat "Ad/Trackers Blocked".
3) Shield stats are stored in NSUserDefaults, and only clear if app is deleted/reinstalled.
4) Color scheme reflects stats in Brave Shields Panel. 

There are likely several improvements to be made to this. Please review.

Thanks!