### PR TITLE
Global stats: split up TP and AB to match desktop. 

### DIFF
--- a/brave/src/frontend/BraveShieldStatsView.swift
+++ b/brave/src/frontend/BraveShieldStatsView.swift
@@ -9,27 +9,27 @@ class BraveShieldStatsView: UIView {
     private let millisecondsPerItem = 50
     private let line = UIView()
     
-    lazy var trackersStatView: StatView = {
+    lazy var adsStatView: StatView = {
         let statView = StatView(frame: CGRectZero)
-        statView.title = "Ad/Trackers \rBlocked"
+        statView.title = "Ads \rBlocked"
         statView.color = UIColor(red: 234/255.0, green: 90/255.0, blue: 45/255.0, alpha: 1.0)
         return statView
     }()
-    
+
+    lazy var trackersStatView: StatView = {
+        let statView = StatView(frame: CGRectZero)
+        statView.title = "Trackers \rBlocked"
+        statView.color = UIColor(red: 25/255.0, green: 152/255.0, blue: 252/255.0, alpha: 1.0)
+        return statView
+    }()
+
     lazy var httpsStatView: StatView = {
         let statView = StatView(frame: CGRectZero)
         statView.title = "HTTPS \rUpgrades"
         statView.color = UIColor(red: 242/255.0, green: 142/255.0, blue: 45/255.0, alpha: 1.0)
         return statView
     }()
-    
-    lazy var scriptsStatView: StatView = {
-        let statView = StatView(frame: CGRectZero)
-        statView.title = "Scripts \rBlocked"
-        statView.color = UIColor(red: 25/255.0, green: 152/255.0, blue: 252/255.0, alpha: 1.0)
-        return statView
-    }()
-    
+
     lazy var timeStatView: StatView = {
         let statView = StatView(frame: CGRectZero)
         statView.title = "Est. Time \rSaved"
@@ -38,7 +38,7 @@ class BraveShieldStatsView: UIView {
     }()
     
     lazy var stats: [StatView] = {
-        return [self.trackersStatView, self.httpsStatView, self.scriptsStatView, self.timeStatView]
+        return [self.adsStatView, self.trackersStatView, self.httpsStatView, self.timeStatView]
     }()
     
     override init(frame: CGRect) {
@@ -84,15 +84,15 @@ class BraveShieldStatsView: UIView {
     }
     
     func update() {
-        trackersStatView.stat = BraveGlobalShieldStats.singleton.adblockAndTp.formatUsingAbbrevation()
+        adsStatView.stat = BraveGlobalShieldStats.singleton.adblock.formatUsingAbbrevation()
+        trackersStatView.stat = BraveGlobalShieldStats.singleton.trackingProtection.formatUsingAbbrevation()
         httpsStatView.stat = BraveGlobalShieldStats.singleton.httpse.formatUsingAbbrevation()
-        scriptsStatView.stat = BraveGlobalShieldStats.singleton.noScript.formatUsingAbbrevation()
         timeStatView.stat = timeSaved
     }
     
     var timeSaved: String {
         get {
-            let estimatedMillisecondsSaved = BraveGlobalShieldStats.singleton.adblockAndTp * millisecondsPerItem
+            let estimatedMillisecondsSaved = (BraveGlobalShieldStats.singleton.adblock + BraveGlobalShieldStats.singleton.trackingProtection) * millisecondsPerItem
             let hours = estimatedMillisecondsSaved < 1000 * 60 * 60 * 24
             let minutes = estimatedMillisecondsSaved < 1000 * 60 * 60
             let seconds = estimatedMillisecondsSaved < 1000 * 60

--- a/brave/src/webfilters/BraveShieldState.swift
+++ b/brave/src/webfilters/BraveShieldState.swift
@@ -323,12 +323,18 @@ public class BraveGlobalShieldStats {
     
     private let prefs = NSUserDefaults.standardUserDefaults()
     
-    var adblockAndTp: Int = 0 {
+    var adblock: Int = 0 {
         didSet {
             NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
         }
     }
-    
+
+    var trackingProtection: Int = 0 {
+        didSet {
+            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
+        }
+    }
+
     var httpse: Int = 0 {
         didSet {
             NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
@@ -347,26 +353,21 @@ public class BraveGlobalShieldStats {
         }
     }
     
-    var noScript: Int = 0 {
-        didSet {
-            NSNotificationCenter.defaultCenter().postNotificationName(BraveGlobalShieldStats.DidUpdateNotification, object: nil)
-        }
-    }
-    
+
     enum Shield: String {
-        case AdblockAndTp = "adblock_and_tp"
+        case Adblock = "adblock"
+        case TrackingProtection = "tracking_protection"
         case HTTPSE = "httpse"
         case SafeBrowsing = "safebrowsing"
         case FpProtection = "fp_protection"
-        case NoScript = "noscript"
     }
     
-    public init() {
-        adblockAndTp = adblockAndTp + prefs.integerForKey(Shield.AdblockAndTp.rawValue)
-        httpse = httpse + prefs.integerForKey(Shield.HTTPSE.rawValue)
-        safeBrowsing = safeBrowsing + prefs.integerForKey(Shield.SafeBrowsing.rawValue)
-        fpProtection = fpProtection + prefs.integerForKey(Shield.FpProtection.rawValue)
-        noScript = noScript + prefs.integerForKey(Shield.NoScript.rawValue)
+    private init() {
+        adblock += prefs.integerForKey(Shield.Adblock.rawValue)
+        trackingProtection += prefs.integerForKey(Shield.TrackingProtection.rawValue)
+        httpse += prefs.integerForKey(Shield.HTTPSE.rawValue)
+        safeBrowsing += prefs.integerForKey(Shield.SafeBrowsing.rawValue)
+        fpProtection += prefs.integerForKey(Shield.FpProtection.rawValue)
     }
     
     public func save() {
@@ -377,11 +378,11 @@ public class BraveGlobalShieldStats {
         })
         
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) { () -> Void in
-            self.prefs.setInteger(self.adblockAndTp, forKey: Shield.AdblockAndTp.rawValue)
+            self.prefs.setInteger(self.adblock, forKey: Shield.Adblock.rawValue)
+            self.prefs.setInteger(self.trackingProtection, forKey: Shield.TrackingProtection.rawValue)
             self.prefs.setInteger(self.httpse, forKey: Shield.HTTPSE.rawValue)
             self.prefs.setInteger(self.safeBrowsing, forKey: Shield.SafeBrowsing.rawValue)
             self.prefs.setInteger(self.fpProtection, forKey: Shield.FpProtection.rawValue)
-            self.prefs.setInteger(self.noScript, forKey: Shield.NoScript.rawValue)
             self.prefs.synchronize()
             
             task = UIBackgroundTaskInvalid

--- a/brave/src/webfilters/UrlProtocol.swift
+++ b/brave/src/webfilters/UrlProtocol.swift
@@ -183,9 +183,10 @@ class URLProtocol: NSURLProtocol {
             } else {
                 returnEmptyResponse()
             }
+            let isBlockedByTP = TrackingProtection.singleton.shouldBlock(request)
             if let url = request.URL?.absoluteString {
                 postAsyncToMain(0.1) {
-                    BrowserTabToUAMapper.userAgentToBrowserTab(ua)?.webView?.shieldStatUpdate(.abAndTpIncrement, increment: 1, affectedUrl: url)
+                    BrowserTabToUAMapper.userAgentToBrowserTab(ua)?.webView?.shieldStatUpdate(isBlockedByTP ? .tpIncrement : .abIncrement, increment: 1, affectedUrl: url)
                 }
             }
             return

--- a/brave/src/webview/BraveWebView.swift
+++ b/brave/src/webview/BraveWebView.swift
@@ -569,7 +569,8 @@ class BraveWebView: UIWebView {
         case reset
         case broadcastOnly
         case httpseIncrement
-        case abAndTpIncrement
+        case abIncrement
+        case tpIncrement
         case jsSetValue
         case fpIncrement
     }
@@ -601,12 +602,14 @@ class BraveWebView: UIWebView {
         case .httpseIncrement:
             shieldStats.httpse += increment
             BraveGlobalShieldStats.singleton.httpse += increment
-        case .abAndTpIncrement:
+        case .abIncrement:
             shieldStats.abAndTp += increment
-            BraveGlobalShieldStats.singleton.adblockAndTp += increment
+            BraveGlobalShieldStats.singleton.adblock += increment
+        case .tpIncrement:
+            shieldStats.abAndTp += increment
+            BraveGlobalShieldStats.singleton.trackingProtection += increment
         case .jsSetValue:
             shieldStats.js = increment
-            BraveGlobalShieldStats.singleton.noScript += increment
         case .fpIncrement:
             shieldStats.fp += increment
             BraveGlobalShieldStats.singleton.fpProtection += increment


### PR DESCRIPTION
Also, remove noScript counter from this view.