### PR TITLE
Fix #639. Updated bookmark query to handle proper SQL encoding.

### DIFF
--- a/Storage/SQL/SQLiteBookmarksSyncing.swift
+++ b/Storage/SQL/SQLiteBookmarksSyncing.swift
@@ -1230,9 +1230,8 @@ public class SQLiteBookmarkBufferStorage_Brave : SQLiteBookmarkBufferStorage {
 
     public func editBookmarkItem(bookmark:BookmarkNode, title:String, parentGUID:String) -> Success {
 
-        let updateQuery = "UPDATE '\(TableBookmarksLocal)' "
-            + "set title='\(title)', parentid='\(parentGUID)' "
-            +  "where guid='\(bookmark.guid)'"
+        let updateQuery = "UPDATE \(TableBookmarksLocal) " +
+            "SET parentid = ?, title = ? WHERE guid='\(bookmark.guid)'"
 
         let newIndex = "(SELECT (COALESCE(MAX(idx), -1) + 1) AS newIndex FROM \(TableBookmarksLocalStructure) WHERE parent = ?)"
         let structSQL = "UPDATE \(TableBookmarksLocalStructure) set parent=?, idx=" +
@@ -1240,7 +1239,7 @@ public class SQLiteBookmarkBufferStorage_Brave : SQLiteBookmarkBufferStorage {
         let structArgs: Args = [parentGUID, parentGUID]
 
 
-        let structureArgs = Args()
+        let structureArgs: Args = [parentGUID, title]
         var err: NSError?
 
         let result = Success()

--- a/brave/tests_src/ui/BookmarksTest.swift
+++ b/brave/tests_src/ui/BookmarksTest.swift
@@ -93,4 +93,29 @@ class BookmarksTest: XCTestCase {
         // close the panel (bug #448)
         app.coordinateWithNormalizedOffset(CGVector(dx: UIScreen.mainScreen().bounds.width, dy:  UIScreen.mainScreen().bounds.height)).tap()
     }
+    
+    func testBookmarkNameEncoding() {
+        UITestUtils.restart(["BRAVE-DELETE-BOOKMARKS"])
+        let app = XCUIApplication()
+        
+        addGoogleAsFirstBookmark()
+
+        let elementsQuery = app.scrollViews.otherElements
+        let toolbarsQuery = elementsQuery.toolbars
+        let googleText = "Google"
+        let testingText = " Te'sti\"ng"
+        
+        toolbarsQuery.buttons["Edit"].tap()
+        
+        elementsQuery.tables["SiteTable"].staticTexts[googleText].tap()
+        elementsQuery.tables.staticTexts["Name"].tap()
+        app.typeText(testingText)
+        
+        elementsQuery.navigationBars["Bookmarks"].buttons["Bookmarks"].tap()
+        toolbarsQuery.buttons["Done"].tap()
+
+        // Make sure single item (didn't duplicate)
+        XCTAssertEqual(app.scrollViews.otherElements.tables["SiteTable"].cells.count, 1)
+        XCTAssertTrue(elementsQuery.tables["SiteTable"].staticTexts[googleText + testingText].exists)
+    }
 }


### PR DESCRIPTION
Using the arguments array instead of string literals in the query encodes the parameters correctly. 