### PR TITLE
Add regional adblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+adblock-regions.txt
+
 *.mobileprovision
 xcuserdata/
 

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		EB9CAB431DC2592700627A39 /* UIWebViewSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = EB9CAB421DC2592700627A39 /* UIWebViewSwizzling.m */; };
 		EB9D8F241D9CCE5F00CA1624 /* BookmarksTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9D8F211D9CCE5F00CA1624 /* BookmarksTest.swift */; };
 		EB9D8F261D9CCE5F00CA1624 /* WebViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9D8F231D9CCE5F00CA1624 /* WebViewTest.swift */; };
+		EBA11E1A1E2EB84800C964E0 /* adblock-regions.txt in Resources */ = {isa = PBXBuildFile; fileRef = EBA11E191E2EB84800C964E0 /* adblock-regions.txt */; };
 		EBACC8551DF9BB3500D5E048 /* SettingsViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBACC8541DF9BB3500D5E048 /* SettingsViewTest.swift */; };
 		EBB345801DAD465C00EE24F0 /* SQLite.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7B9A62DB1C4002B1005C83DC /* SQLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EBE50B831DAE8D77000BC0A1 /* BookmarksTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE50B7C1DAE8D70000BC0A1 /* BookmarksTest.swift */; };
@@ -1288,6 +1289,7 @@
 		EB9CAB421DC2592700627A39 /* UIWebViewSwizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UIWebViewSwizzling.m; path = brave/src/webview/UIWebViewSwizzling.m; sourceTree = "<group>"; };
 		EB9D8F211D9CCE5F00CA1624 /* BookmarksTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTest.swift; sourceTree = "<group>"; };
 		EB9D8F231D9CCE5F00CA1624 /* WebViewTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewTest.swift; sourceTree = "<group>"; };
+		EBA11E191E2EB84800C964E0 /* adblock-regions.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "adblock-regions.txt"; path = "brave/adblock-regions.txt"; sourceTree = SOURCE_ROOT; };
 		EBACC8541DF9BB3500D5E048 /* SettingsViewTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewTest.swift; sourceTree = "<group>"; };
 		EBE50B7C1DAE8D70000BC0A1 /* BookmarksTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksTest.swift; sourceTree = "<group>"; };
 		EBE50B861DAEC689000BC0A1 /* Deferred.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Deferred.framework; path = Carthage/Build/iOS/Deferred.framework; sourceTree = "<group>"; };
@@ -3432,6 +3434,7 @@
 				EB8F569C1DD13DF300679A78 /* FiraSans-BoldItalic.ttf in Resources */,
 				886E3B0001BC705ACFC4AD45 /* adInfo-wrapper.js in Resources */,
 				507ACE2A12D675DAF9C79198 /* adInfo.js in Resources */,
+				EBA11E1A1E2EB84800C964E0 /* adblock-regions.txt in Resources */,
 				E4309BC56F1431FEA791E157 /* BlankTargetDetector.js in Resources */,
 				EB4E15ED1DB7F36600A4C7EA /* Localizable.strings in Resources */,
 				EB8F569F1DD13DF300679A78 /* FiraSans-Light.ttf in Resources */,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -300,6 +300,7 @@ extension Strings {
     public static let Fingerprinting_Protection_wrapped = NSLocalizedString("Fingerprinting\nProtection", comment: "blocking stat title")
     public static let Shields_Overview = NSLocalizedString("Site Shields allow you to control when ads and trackers are blocked for each site that you visit. If you prefer to see ads on a specific site, you can enable them here.", comment: "shields overview message")
     public static let Shields_Overview_Footer = NSLocalizedString("Note: Some sites may require scripts to work properly so this shield is turned off by default.", comment: "shields overview footer message")
+    public static let Use_regional_adblock = NSLocalizedString("Use regional adblock", comment: "Setting to allow user in non-english locale to use adblock rules specifc to their language")
 }
 
 

--- a/Utils/AppConstants.swift
+++ b/Utils/AppConstants.swift
@@ -15,6 +15,8 @@ public enum AppBuildChannel {
 public struct AppConstants {
 
     public static let IsRunningTestNonUI = NSClassFromString("XCTestCase") != nil
+    public static var IsRunningUITest = false
+    public static var IsRunningTest:Bool { return IsRunningTestNonUI || IsRunningUITest }
 
     // True if this process is executed as part of a Fastlane Snapshot test
     public static let IsRunningFastlaneSnapshot = NSProcessInfo.processInfo().arguments.contains("FASTLANE_SNAPSHOT")
@@ -37,15 +39,6 @@ public struct AppConstants {
 
     /// Whether we just mirror (false) or actively merge and upload (true).
     public static let shouldMergeBookmarks = false
-
-    /// Flag indiciating if we are running in Debug mode or not.
-    public static let isDebug: Bool = {
-#if MOZ_CHANNEL_DEBUG
-    return true
-#else
-    return false
-#endif
-    }()
 
 
     /// Enables/disables the Login manager UI by hiding the 'Logins' setting item.

--- a/brave/setup.sh
+++ b/brave/setup.sh
@@ -32,3 +32,5 @@ echo GENERATED_BUILD_ID=`date +"%y.%m.%d.%H"` >> xcconfig/local-def.xcconfig
 
 npm update
 
+node -e "require('./node_modules/ad-block/lib/regions.js').forEach((x) =>{ if (x.lang) {console.log(x.lang + ',' + x.uuid)} } )" > adblock-regions.txt
+

--- a/brave/src/BraveApp.swift
+++ b/brave/src/BraveApp.swift
@@ -150,7 +150,7 @@ class BraveApp {
             }
         }
 
-        AdBlocker.singleton.networkFileLoader.loadData()
+        AdBlocker.singleton.startLoading()
         SafeBrowsing.singleton.networkFileLoader.loadData()
         TrackingProtection.singleton.networkFileLoader.loadData()
         HttpsEverywhere.singleton.networkFileLoader.loadData()

--- a/brave/src/BraveApp.swift
+++ b/brave/src/BraveApp.swift
@@ -143,11 +143,16 @@ class BraveApp {
         if args.contains("BRAVE-UI-TEST") || AppConstants.IsRunningTestNonUI {
             // Maybe we will need a specific flag to keep tabs for restoration testing
             BraveApp.isSafeToRestoreTabs = false
-
+            AppConstants.IsRunningUITest = !AppConstants.IsRunningTestNonUI
+            
             if args.filter({ $0.startsWith("BRAVE") }).count == 1 || AppConstants.IsRunningTestNonUI { // only contains 1 arg
                 BraveApp.getPrefs()!.setInt(1, forKey: IntroViewControllerSeenProfileKey)
                 BraveApp.getPrefs()!.setInt(1, forKey: BraveUX.PrefKeyOptInDialogWasSeen)
             }
+        }
+
+        if args.contains("LOCALE=RU") {
+            AdBlocker.singleton.currentLocaleCode = "ru"
         }
 
         AdBlocker.singleton.startLoading()

--- a/brave/src/frontend/BraveSettingsView.swift
+++ b/brave/src/frontend/BraveSettingsView.swift
@@ -97,6 +97,19 @@ class BraveSettingsView : AppSettingsTableViewController {
         }
 
 
+        var shieldSettingsList = [BoolSetting(prefs: prefs, prefKey: AdBlocker.prefKey, defaultValue: true, titleText: Strings.Block_Ads_and_Tracking),
+                                  BoolSetting(prefs: prefs, prefKey: HttpsEverywhere.prefKey, defaultValue: true, titleText: Strings.HTTPS_Everywhere),
+                                  BoolSetting(prefs: prefs, prefKey: SafeBrowsing.prefKey, defaultValue: true, titleText: Strings.Block_Phishing_and_Malware),
+                                  BoolSetting(prefs: prefs, prefKey: kPrefKeyNoScriptOn, defaultValue: false, titleText: Strings.Block_Scripts),
+                                  BoolSetting(prefs: prefs, prefKey: kPrefKeyFingerprintProtection, defaultValue: false, titleText: Strings.Fingerprinting_Protection)
+                                  ]
+
+        let adblockRegionOption = AdBlocker.singleton.isRegionalAdblockPossible()
+        if adblockRegionOption.hasRegionalFile {
+            let defaultOn = adblockRegionOption.isDefaultSettingOn
+            shieldSettingsList.append(BoolSetting(prefs: prefs, prefKey: AdBlocker.prefKeyUseRegional, defaultValue: defaultOn, titleText: Strings.Use_regional_adblock))
+        }
+
         settings += [
             SettingSection(title: NSAttributedString(string: Strings.General), children: generalSettings),
             SettingSection(title: NSAttributedString(string: Strings.Privacy), children:
@@ -111,13 +124,7 @@ class BraveSettingsView : AppSettingsTableViewController {
                         }
                     })]
             ),
-            SettingSection(title: NSAttributedString(string: Strings.Brave_Shield_Defaults), children:
-                [BoolSetting(prefs: prefs, prefKey: AdBlocker.prefKey, defaultValue: true, titleText: Strings.Block_Ads_and_Tracking),
-                    BoolSetting(prefs: prefs, prefKey: HttpsEverywhere.prefKey, defaultValue: true, titleText: Strings.HTTPS_Everywhere),
-                    BoolSetting(prefs: prefs, prefKey: SafeBrowsing.prefKey, defaultValue: true, titleText: Strings.Block_Phishing_and_Malware),
-                    BoolSetting(prefs: prefs, prefKey: kPrefKeyNoScriptOn, defaultValue: false, titleText: Strings.Block_Scripts),
-                    BoolSetting(prefs: prefs, prefKey: kPrefKeyFingerprintProtection, defaultValue: false, titleText: Strings.Fingerprinting_Protection)
-                ])]
+            SettingSection(title: NSAttributedString(string: Strings.Brave_Shield_Defaults), children: shieldSettingsList)]
 
         //#if !DISABLE_INTRO_SCREEN
         settings += [

--- a/brave/src/webfilters/AdBlocker.swift
+++ b/brave/src/webfilters/AdBlocker.swift
@@ -3,41 +3,100 @@
 import Foundation
 import Shared
 
-private let _singleton = AdBlocker()
+class AdblockNetworkDataFileLoader: NetworkDataFileLoader {
+    var lang = "en"
+}
+
+typealias localeCode = String
 
 class AdBlocker {
+    static let singleton = AdBlocker()
+
     static let prefKey = "braveBlockAdsAndTracking"
     static let prefKeyDefaultValue = true
+    static let prefKeyUseRegional = "braveAdblockUseRegional"
+    static let prefKeyUseRegionalDefaultValue = true
     static let dataVersion = "2"
 
-    lazy var abpFilterLibWrapper: ABPFilterLibWrapper = { return ABPFilterLibWrapper() }()
-
-    lazy var networkFileLoader: NetworkDataFileLoader = {
-        let dataUrl = NSURL(string: "https://s3.amazonaws.com/adblock-data/\(dataVersion)/ABPFilterParserData.dat")!
-        let dataFile = "abp-data-\(dataVersion).dat"
-        let loader = NetworkDataFileLoader(url: dataUrl, file: dataFile, localDirName: "abp-data")
-        loader.delegate = self
-        return loader
-    }()
-
-    var fifoCacheOfUrlsChecked = FifoDict()
     var isNSPrefEnabled = true
+    private var fifoCacheOfUrlsChecked = FifoDict()
+    private var regionToS3FileName = [localeCode: String]()
+    private var networkLoaders = [localeCode: AdblockNetworkDataFileLoader]()
+    private lazy var abpFilterLibWrappers: [localeCode: ABPFilterLibWrapper] = { return ["en": ABPFilterLibWrapper()] }()
+    private var currentLocaleCode: localeCode = "en"
+    private var isRegionalAdblockEnabled: Bool? = nil
+    private let wellTestedAdblockRegions = ["ru", "uk", "be", "hi"]
 
     private init() {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(AdBlocker.prefsChanged(_:)), name: NSUserDefaultsDidChangeNotification, object: nil)
+
         updateEnabledState()
+
+        networkLoaders["en"] = getNetworkLoader(forLocale: "en", name: "ABPFilterParserData")
+
+        currentLocaleCode = NSLocale.preferredLanguages()[0]
+
+        let regional = try! NSString(contentsOfFile: NSBundle.mainBundle().pathForResource("adblock-regions", ofType: "txt")!, encoding: NSUTF8StringEncoding) as String
+        regional.componentsSeparatedByString("\n").forEach {
+            let parts = String($0).componentsSeparatedByString(",")
+            if parts.count == 2 {
+                regionToS3FileName[parts[0]] = parts[1] // looks like: "cs": "7CCB6921-7FDA"
+            }
+        }
+
+        // data loading is triggered explicitly at end of startup
+        updateRegionalAdblockEnabledState(newRegionsLoadImmediately: false)
     }
 
-    class var singleton: AdBlocker {
-        return _singleton
+    private func getNetworkLoader(forLocale locale: localeCode, name: String) -> AdblockNetworkDataFileLoader {
+        let dataUrl = NSURL(string: "https://s3.amazonaws.com/adblock-data/\(AdBlocker.dataVersion)/\(name).dat")!
+        let dataFile = "abp-data-\(AdBlocker.dataVersion)-\(locale).dat"
+        let loader = AdblockNetworkDataFileLoader(url: dataUrl, file: dataFile, localDirName: "abp-data")
+        loader.lang = locale
+        loader.delegate = self
+        return loader
+    }
+
+    func startLoading() {
+        print(networkLoaders)
+        networkLoaders.forEach { $0.1.loadData() }
+    }
+
+    func isRegionalAdblockPossible() -> (hasRegionalFile: Bool, isDefaultSettingOn: Bool) {
+        return (hasRegionalFile: currentLocaleCode != "en" && regionToS3FileName[currentLocaleCode] != nil,
+                isDefaultSettingOn: isRegionalAdblockEnabled ?? false)
     }
 
     func updateEnabledState() {
         isNSPrefEnabled = BraveApp.getPrefs()?.boolForKey(AdBlocker.prefKey) ?? AdBlocker.prefKeyDefaultValue
     }
 
+    private func updateRegionalAdblockEnabledState(newRegionsLoadImmediately startLoad: Bool) {
+        isRegionalAdblockEnabled = BraveApp.getPrefs()?.boolForKey(AdBlocker.prefKeyUseRegional)
+        if isRegionalAdblockEnabled == nil && wellTestedAdblockRegions.contains(currentLocaleCode) {
+            // in this case it is only enabled by default for well tested regions (leave set to nil otherwise)
+            isRegionalAdblockEnabled = true
+        }
+
+        if currentLocaleCode != "en" && (isRegionalAdblockEnabled ?? false) {
+            if let file = regionToS3FileName[currentLocaleCode] {
+                if networkLoaders[currentLocaleCode] == nil {
+                    networkLoaders[currentLocaleCode] = getNetworkLoader(forLocale: currentLocaleCode, name: file)
+                    abpFilterLibWrappers[currentLocaleCode] = ABPFilterLibWrapper()
+                    if startLoad {
+                        networkLoaders[currentLocaleCode]!.loadData()
+                    }
+                }
+            } else {
+                NSLog("No custom adblock file for \(currentLocaleCode)")
+            }
+        }
+    }
+
     @objc func prefsChanged(info: NSNotification) {
         updateEnabledState()
+
+        updateRegionalAdblockEnabledState(newRegionsLoadImmediately: true)
     }
 
     // We can add whitelisting logic here for puzzling adblock problems
@@ -119,7 +178,7 @@ class AdBlocker {
         defer { objc_sync_exit(self) }
 
         guard let url = request.URL else {
-                return false
+            return false
         }
 
         if url.host?.contains("forbes.com") ?? false {
@@ -163,10 +222,16 @@ class AdBlocker {
             }
         }
 
-        let isBlocked = abpFilterLibWrapper.isBlockedConsideringType(url.absoluteString,
-                                                                     mainDocumentUrl: mainDocDomain,
-                                                                     acceptHTTPHeader:request.valueForHTTPHeaderField("Accept"))
+        var isBlocked = false
+        for (_, adblocker) in abpFilterLibWrappers {
+            isBlocked = adblocker.isBlockedConsideringType(url.absoluteString,
+                                                           mainDocumentUrl: mainDocDomain,
+                                                           acceptHTTPHeader:request.valueForHTTPHeaderField("Accept"))
 
+            if isBlocked {
+                break
+            }
+        }
         fifoCacheOfUrlsChecked.addItem(key, value: isBlocked)
 
         #if LOG_AD_BLOCK
@@ -180,16 +245,24 @@ class AdBlocker {
 }
 
 extension AdBlocker: NetworkDataFileLoaderDelegate {
-    
-    func fileLoader(_: NetworkDataFileLoader, setDataFile data: NSData?) {
-        abpFilterLibWrapper.setDataFile(data)
-    }
-    
-    func fileLoaderHasDataFile(_: NetworkDataFileLoader) -> Bool {
-        return abpFilterLibWrapper.hasDataFile()
+
+    func fileLoader(loader: NetworkDataFileLoader, setDataFile data: NSData?) {
+        guard let loader = loader as? AdblockNetworkDataFileLoader, adblocker = abpFilterLibWrappers[loader.lang] else {
+            assert(false)
+            return
+        }
+        adblocker.setDataFile(data)
     }
 
-    func fileLoaderDelegateWillHandleInitialRead(_: NetworkDataFileLoader) -> Bool {
+    func fileLoaderHasDataFile(loader: NetworkDataFileLoader) -> Bool {
+        guard let loader = loader as? AdblockNetworkDataFileLoader, adblocker = abpFilterLibWrappers[loader.lang] else {
+            assert(false)
+            return false
+        }
+        return adblocker.hasDataFile()
+    }
+
+    func fileLoaderDelegateWillHandleInitialRead(loader: NetworkDataFileLoader) -> Bool {
         return false
     }
 }

--- a/brave/tests_src/ui/WebViewTest.swift
+++ b/brave/tests_src/ui/WebViewTest.swift
@@ -55,4 +55,23 @@ class WebViewTest: XCTestCase {
         found = app.staticTexts.elementMatchingPredicate(search)
         XCTAssert(found.exists, "didn't find UA for desktop")
     }
+
+    func testRegionalAdblock() {
+        UITestUtils.restart(["LOCALE=RU"])
+        let app = XCUIApplication()
+        UITestUtils.loadSite(app, "https://sputniknews.com/russia")
+
+        // waitForExpecation with `exists` predicate is randomly failing, sigh. do this instead
+        for _ in 0..<5 {
+            let blockedUrl = app.staticTexts["blocked-url"]
+            if !blockedUrl.exists {
+                sleep(1)
+                continue
+            }
+
+            let str = blockedUrl.value as? String
+            XCTAssert(str?.hasPrefix("ru ") ?? false)
+            break
+        }
+    }
 }


### PR DESCRIPTION
Fix #564

@jhreis I need to research how to test this:
* without manually setting the locale in the simulator run scheme.
* check if a particular known ad is blocked for a specified region

Maybe I'll make that a separate follow up bug, or we can keep this open while test cases are worked out.

BTW, the pref for this is a but odd: it only defaults to on for well-tested regions, otherwise the user must manually toggle the pref on for their region.