### PR TITLE
The location text field is losing focus immediately after we try set …

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -379,7 +379,9 @@ class URLBarView: UIView {
         } else {
             // Copy the current URL to the editable text field, then activate it.
             self.locationTextField?.text = locationText
-            dispatch_async(dispatch_get_main_queue()) {
+
+            // something is resigning the first responder immediately after setting it. A short delay for events to process fixes it.
+            postAsyncToMain(0.1) {
                 self.locationTextField?.becomeFirstResponder()
             }
         }


### PR DESCRIPTION
…the focus when pressing the add tab button.

I can't find what is cancelling first responders status, but a short delay before setting first responder fixes this.