### PR TITLE
Added support for bitwarden app extension bundle id - resolves #743

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -124,6 +124,7 @@ private extension ShareExtensionHelper {
         // If your extension's bundle identifier does not contain "password", simply submit a pull request by adding your bundle identifier.
         return (activityType?.rangeOfString("password") != nil)
             || (activityType == "com.lastpass.ilastpass.LastPassExt")
+            || (activityType == "com.8bit.bitwarden.find-login-action-extension")
 
     }
 


### PR DESCRIPTION
This PR adds support for bitwarden's auto-fill app extension so that it can be used from the share menu.

resolves https://github.com/brave/browser-ios/issues/743

Learn more about bitwarden at https://bitwarden.com

NOTE: bitwarden was recently added to the desktop browser here: https://github.com/brave/browser-laptop/pull/6918