### PR TITLE
fix #863 - Normalized url is used to lookup core data domains

### DIFF
--- a/brave/src/data/Domain.swift
+++ b/brave/src/data/Domain.swift
@@ -127,26 +127,27 @@ class Domain: NSManagedObject {
                 let results = try context.executeFetchRequest(fetchRequest)
                 for obj in results {
                     let domain = obj as! Domain
-                    guard let url = domain.url else { continue }
+                    guard let urlString = domain.url, url = NSURL(string: urlString) else { continue }
+                    let normalizedUrl = url.normalizedHost()
 
-                    print(url)
+                    print(normalizedUrl)
                     if let shield = domain.shield_allOff {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.AllOff, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.AllOff, shield.boolValue))
                     }
                     if let shield = domain.shield_adblockAndTp {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.AdblockAndTp, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.AdblockAndTp, shield.boolValue))
                     }
                     if let shield = domain.shield_safeBrowsing {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.SafeBrowsing, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.SafeBrowsing, shield.boolValue))
                     }
                     if let shield = domain.shield_httpse {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.HTTPSE, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.HTTPSE, shield.boolValue))
                     }
                     if let shield = domain.shield_fpProtection {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.FpProtection, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.FpProtection, shield.boolValue))
                     }
                     if let shield = domain.shield_noScript {
-                        BraveShieldState.setInMemoryforDomain(url, setState: (.NoScript, shield.boolValue))
+                        BraveShieldState.setInMemoryforDomain(normalizedUrl, setState: (.NoScript, shield.boolValue))
                     }
                 }
             } catch {


### PR DESCRIPTION
Fix for issue #863 .

I noticed the site label is normalized and being used to set the in-memory shield state when a Domain is updated. When a domain is created for use with core data, it is created setting the URL using `let domainUrl = (url?.scheme ?? "http") + "://" + (url?.normalizedHost() ?? "")`. This seems to be where the issue lies. 

When the app starts up fresh, it loads the shields into memory, but because the domain was set with a scheme, it loads every saved host with it (eg: https://brave.com). Requests set the shield state at `BraveWebView.swift:371` with the normalized url, so it seems normalizing the host when loading from core data resolves the issue.