### PR TITLE
Fix #826 - Tab bar is now updated to show upon exiting private browsing

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -449,6 +449,7 @@ extension TabManager {
             getApp().tabManager.addTab()
         }
         getApp().tabManager.selectTab(getApp().tabManager.tabs.displayedTabsForCurrentPrivateMode.first)
+        getApp().browserViewController.urlBar.updateTabsBarShowing()
     }
 }
 


### PR DESCRIPTION
Fix for #826 

When leaving private browsing mode the TabManager reverts back to non-private tabs, but there was never a call to update the tabs bar showing once the tabs were updated for display. This PR explicitly makes that call once all tabs are added back to get the tab bar to show if needed.