### PR TITLE
Fix #873 Clearing partial data destroys all tabs

### DIFF
--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -350,8 +350,10 @@ class TabManager : NSObject {
         }
         tabs.removeTab(tab)
 
-        if let tabID = tab.tabID {
-            TabMO.removeTab(tabID)
+        if flushToDisk {
+            if let tabID = tab.tabID {
+                TabMO.removeTab(tabID)
+            }
         }
         
         // There's still some time between this and the webView being destroyed.
@@ -373,7 +375,9 @@ class TabManager : NSObject {
             selectTab(tabs.displayedTabsForCurrentPrivateMode.first)
         }
         
-        preserveTabs()
+        if flushToDisk {
+            preserveTabs()
+        }
     }
 
     /// Removes all private tabs from the manager.
@@ -390,12 +394,12 @@ class TabManager : NSObject {
         }
     }
 
-    func removeAll() {
+    func removeAll(flushToDisk: Bool) {
         objc_sync_enter(self); defer { objc_sync_exit(self) }
         let tabs = self.tabs
 
         for tab in tabs.internalTabList {
-            self.removeTab(tab, flushToDisk: false, notify: true, createTabIfNoneLeft: false)
+            self.removeTab(tab, flushToDisk: flushToDisk, notify: true, createTabIfNoneLeft: false)
         }
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -350,10 +350,8 @@ class TabManager : NSObject {
         }
         tabs.removeTab(tab)
 
-        if flushToDisk {
-            if let tabID = tab.tabID {
-                TabMO.removeTab(tabID)
-            }
+        if let tabID = tab.tabID {
+            TabMO.removeTab(tabID)
         }
         
         // There's still some time between this and the webView being destroyed.
@@ -375,9 +373,7 @@ class TabManager : NSObject {
             selectTab(tabs.displayedTabsForCurrentPrivateMode.first)
         }
         
-        if flushToDisk {
-            preserveTabs()
-        }
+        preserveTabs()
     }
 
     /// Removes all private tabs from the manager.
@@ -394,12 +390,12 @@ class TabManager : NSObject {
         }
     }
 
-    func removeAll(flushToDisk: Bool) {
+    func removeAll() {
         objc_sync_enter(self); defer { objc_sync_exit(self) }
         let tabs = self.tabs
 
         for tab in tabs.internalTabList {
-            self.removeTab(tab, flushToDisk: flushToDisk, notify: true, createTabIfNoneLeft: false)
+            self.removeTab(tab, flushToDisk: false, notify: true, createTabIfNoneLeft: false)
         }
     }
 

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -20,6 +20,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
     private var clearButton: UITableViewCell?
 
     var profile: Profile!
+    var savedTabs: [SavedTab]?
 
     private var gotNotificationDeathOfAllWebViews = false
 
@@ -164,7 +165,7 @@ class ClearPrivateDataTableViewController: UITableViewController {
             } else {
                 ClearPrivateDataTableViewController.clearPrivateData(clear).uponQueue(dispatch_get_main_queue()) {
                     // TODO: add API to avoid add/remove
-                    getApp().tabManager.removeTab(getApp().tabManager.addTab()!, createTabIfNoneLeft: true)
+                    getApp().tabManager.restoreTabs()
                 }
             }
 
@@ -185,7 +186,12 @@ class ClearPrivateDataTableViewController: UITableViewController {
         if (BraveWebView.allocCounter == 0) {
             allWebViewsKilled()
         } else {
-            getApp().tabManager.removeAll()
+            var flushToDisk = false
+            if self.toggles[0] {
+                // Remove from TabMO only when Browsing History is toggled
+                flushToDisk = true
+            }
+            getApp().tabManager.removeAll(flushToDisk)
             postAsyncToMain(0.5, closure: {
                 if !self.gotNotificationDeathOfAllWebViews {
                     getApp().tabManager.tabs.internalTabList.forEach { $0.deleteWebView(isTabDeleted: true) }

--- a/brave/src/data/TabMO.swift
+++ b/brave/src/data/TabMO.swift
@@ -50,8 +50,7 @@ extension TabManager {
     }
 
     func restoreTabs() {
-        struct RunOnceAtStartup { static var token: dispatch_once_t = 0 }
-        dispatch_once(&RunOnceAtStartup.token, restoreTabsInternal)
+        restoreTabsInternal()
     }
 
     private func restoreTabsInternal() {
@@ -88,7 +87,7 @@ extension TabManager {
         if tabCount > 0 {
             delegates.forEach { $0.value?.tabManagerDidRestoreTabs(self) }
         } else {
-            tabToSelect = addTab()
+            tabToSelect = addTab(id: TabMO.freshTab())
         }
 
         if let tab = tabToSelect {

--- a/brave/src/data/TabMO.swift
+++ b/brave/src/data/TabMO.swift
@@ -50,7 +50,8 @@ extension TabManager {
     }
 
     func restoreTabs() {
-        restoreTabsInternal()
+        struct RunOnceAtStartup { static var token: dispatch_once_t = 0 }
+        dispatch_once(&RunOnceAtStartup.token, restoreTabsInternal)
     }
 
     private func restoreTabsInternal() {


### PR DESCRIPTION
* Clear all tabs only when Browsing History is toggled
* Use preserveTabs and restoreTabs to recover tabs after clearing data
* Remove dispatch_once in restoreTabs