### PR TITLE
Add shebang to setup.sh

### DIFF
--- a/brave/setup.sh
+++ b/brave/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 [[ -e setup.sh  ]] || { echo 'setup.sh must be run from brave directory'; exit 1; }
 
 # Pro Tip for ad-hoc building: add your app id as an arg, like ./setup.sh org.foo.myapp


### PR DESCRIPTION
I use the [fish shell](https://fishshell.com/), which is not bash compatible. While following the [setup instructions in the README](https://github.com/brave/browser-ios#setup), I encountered the following error:

```
$ ./setup.sh your.fake.appid
Failed to execute process './setup.sh'. Reason:
exec: Exec format error
The file './setup.sh' is marked as an executable but could not be run by the operating system.
```

I noticed that `./setup.sh` lacks a shebang, which creates an undocumented implicit dependency: the script must be run from within a compatible shell. Adding a shebang is a quick and easy way to get this script to work, regardless of the developer's preferred shell.

I wasn't sure if you would prefer `sh` or `bash`; if you want me to change it, let me know.