### PR TITLE
tab issues being fixed here: 

### DIFF
--- a/Client/Frontend/Browser/Browser.swift
+++ b/Client/Frontend/Browser/Browser.swift
@@ -253,9 +253,7 @@ class Browser: NSObject, BrowserWebViewDelegate {
         // we extract the information needed to restore the tabs and create a NSURLRequest with the custom session restore URL
         // to trigger the session restore via custom handlers
         if let sessionData = restorationData {
-            #if !BRAVE // no idea why restoring is needed, but it causes the displayed url not to update, which is bad
-                restoring = true
-            #endif
+            restoring = true
             lastTitle = sessionData.title
             if let title = lastTitle {
                 webView.title = title

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabManagerDelegate.swift
@@ -105,7 +105,7 @@ extension BrowserViewController: TabManagerDelegate {
         updateInContentHomePanel(selected?.url)
     }
 
-    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?) {}
+    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?, at: Int?) {}
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Browser) {
         // If we are restoring tabs then we update the count once at the end

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -828,7 +828,8 @@ class BrowserViewController: UIViewController {
             switchBrowsingMode(toPrivate: true)
         }
         
-        tabManager.addTabAndSelect(request)
+        //tabManager.addTabAndSelect(request)
+        tabManager.addAdjacentTabAndSelect(request)
     }
 
     func openBlankNewTabAndFocus(isPrivate: Bool = false) {

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -828,7 +828,6 @@ class BrowserViewController: UIViewController {
             switchBrowsingMode(toPrivate: true)
         }
         
-        //tabManager.addTabAndSelect(request)
         tabManager.addAdjacentTabAndSelect(request)
     }
 

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -291,6 +291,7 @@ class TabManager : NSObject {
     
     fileprivate func restoreTabsInternal() {
         var tabToSelect: Browser?
+        isRestoring = true
         
         // Do not want to load any tabs if PM is enabled
         assert(!PrivateBrowsing.singleton.isOn, "Tab restoration should never happen in PM")
@@ -344,6 +345,8 @@ class TabManager : NSObject {
                 self.selectTab(tab)
             }
         }
+        
+        isRestoring = false
     }
 
     fileprivate func limitInMemoryTabs() {

--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -611,7 +611,7 @@ extension TabTrayController: TabManagerDelegate {
     func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Browser?) {
     }
 
-    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?) {
+    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?, at: Int?) {
     }
 
     func tabManager(_ tabManager: TabManager, didAddTab tab: Browser) {

--- a/brave/src/frontend/tabsbar/TabWidget.swift
+++ b/brave/src/frontend/tabsbar/TabWidget.swift
@@ -76,7 +76,9 @@ class TabWidget : UIView {
 
         close.addTarget(self, action: #selector(clicked), for: .touchUpInside)
         title.addTarget(self, action: #selector(selected), for: .touchUpInside)
-        title.setTitle("", for: .normal)
+        
+        let t = TabMO.getByID(browser.tabID ?? "", context: DataController.shared.mainThreadContext)
+        title.setTitle(t?.title, for: .normal)
         [close, title, separatorLine].forEach { addSubview($0) }
 
         close.setImage(UIImage(named: "stop")?.withRenderingMode(.alwaysTemplate), for: .normal)

--- a/brave/src/frontend/tabsbar/TabsBarViewController.swift
+++ b/brave/src/frontend/tabsbar/TabsBarViewController.swift
@@ -203,10 +203,11 @@ class TabsBarViewController: UIViewController {
         tabs.append(t)
         
         if let index = at, index > -1 && index < tabs.count {
-            // Trottle layout. Reduce re-layout bottleneck on fast tab creation (bootup)
-            if !insertTabScheduled {
-                weak var weakSelf = self
+            // Ignore all of this on bootup
+            if !getApp().tabManager.isRestoring && !insertTabScheduled {
+                // Trottle layout. Reduce re-layout bottleneck on fast tab creation.
                 insertTabScheduled = true
+                weak var weakSelf = self
                 postAsyncToMain(0.2) {
                     weakSelf?.insertTabScheduled = false
                     weakSelf?.isAddTabAnimationRunning = false

--- a/brave/src/frontend/tabsbar/TabsBarViewController.swift
+++ b/brave/src/frontend/tabsbar/TabsBarViewController.swift
@@ -29,6 +29,7 @@ class TabsBarViewController: UIViewController {
     }
 
     fileprivate var isAddTabAnimationRunning = false
+    fileprivate var insertTabScheduled = false
     
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -184,7 +185,7 @@ class TabsBarViewController: UIViewController {
     }
 
 
-    func addTab(_ browser: Browser) -> TabWidget {
+    func addTab(_ browser: Browser, at: Int?) -> TabWidget {
         let t = TabWidget(browser: browser, parentScrollView: scrollView)
         t.delegate = self
         
@@ -200,6 +201,22 @@ class TabsBarViewController: UIViewController {
         
         t.remakeLayout(tabs.last?.spacerRight != nil ? tabs.last!.spacerRight : self.spacerLeftmost, width: w, scrollView: scrollView)
         tabs.append(t)
+        
+        if let index = at, index > -1 && index < tabs.count {
+            // Trottle layout. Reduce re-layout bottleneck on fast tab creation (bootup)
+            if !insertTabScheduled {
+                weak var weakSelf = self
+                insertTabScheduled = true
+                postAsyncToMain(0.2) {
+                    weakSelf?.insertTabScheduled = false
+                    weakSelf?.isAddTabAnimationRunning = false
+                    weakSelf?.moveTab(t, index: index)
+                    weakSelf?.recalculateTabView()
+                    weakSelf?.updateSeparatorLineBetweenTabs()
+                }
+                return t
+            }
+        }
 
         if self.isVisible {
             UIView.animate(withDuration: 0.2, animations: {
@@ -341,7 +358,7 @@ extension TabsBarViewController: TabManagerDelegate {
         tabs.removeAll()
 
         tabManager.tabs.internalTabList.forEach {
-            let t = addTab($0)
+            let t = addTab($0, at: nil)
             t.setTitle($0.lastTitle)
             if tabManager.selectedTab === $0 {
                 tabWidgetSelected(t)
@@ -360,7 +377,7 @@ extension TabsBarViewController: TabManagerDelegate {
         updateSeparatorLineBetweenTabs()
     }
 
-    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?) {
+    func tabManager(_ tabManager: TabManager, didCreateWebView tab: Browser, url: URL?, at: Int?) {
         if let t = tabs.find({ $0.browser === tab }) {
             if let wv = t.browser?.webView {
                 wv.delegatesForPageState.append(BraveWebView.Weak_WebPageStateDelegate(value: t))
@@ -368,7 +385,7 @@ extension TabsBarViewController: TabManagerDelegate {
             return
         }
 
-        let t = addTab(tab)
+        let t = addTab(tab, at: at)
         if let url = url {
             let title = url.baseDomain
             t.setTitle(title)


### PR DESCRIPTION
1. tab titles on tab bar were not being restored on relaunch and creating a broken experience, these are now restored from CD. 
2.  tab insertion was removed to fix performance on relaunching app, with several tabs this was noticeable on older devices. Added a scheduling mechanism to throttle re-layout, tabs continue to be restored quickly while preserving the ux of tab insertion, expanded this to include tabs opened from javascript _blank targets which makes a better ux on sites like fb
3. zombie tab restores should no longer hit CoreData
4. preserve selected tab on restore, this was broken before.
5. keep sort order on tabs when launching new ones, requires a pass through open tabs and writes to CD (ignored on zombie tabs)
6. put back a feature that was removed regarding state of Browser and restoring, not using in commits here but original comment posted with commit was no longer relevant given the tabs title is being populated on launch. would be great to have this for other potential optimizations. 