### PR TITLE
fix #1113 - snackbar background color no longer visible due to regression

### DIFF
--- a/Client/Frontend/Widgets/SnackBar.swift
+++ b/Client/Frontend/Widgets/SnackBar.swift
@@ -95,7 +95,7 @@ class SnackBar: UIView {
         contentView = UIView()
         buttonsView = Toolbar()
         backgroundView = UIView()
-        backgroundView.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
+        backgroundView.backgroundColor = UIColor(rgb: 0xe8e8e8)
 
         super.init(frame: CGRect.zero)
 
@@ -115,8 +115,8 @@ class SnackBar: UIView {
         contentView = UIView()
         buttonsView = Toolbar()
         backgroundView = UIView()
-        backgroundView.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
-
+        backgroundView.backgroundColor = UIColor(rgb: 0xe8e8e8)
+        
         super.init(frame: frame)
     }
 


### PR DESCRIPTION
Regression at: https://github.com/brave/browser-ios/commit/27686f4dd57582730beb7e9f82d9597254d1ab67