### PR TITLE
fix #1171 - method for confirming old pin before setting a new one, a…

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -368,11 +368,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
         requirePinIfNeeded(profile: appProfile)
     }
     
-    private func requirePinIfNeeded(profile: Profile) {
+    func requirePinIfNeeded(profile: Profile) {
         // Check for browserLock settings
         if profile.prefs.boolForKey(kPrefKeyBrowserLock) == true {
             if securityWindow != nil  {
                 securityViewController?.start()
+                // This could have been changed elsewhere, not the best approach.
+                securityViewController?.successCallback = { (success) in
+                    postAsyncToMain {
+                        self.securityWindow?.isHidden = true
+                    }
+                }
                 securityWindow?.isHidden = false
                 return
             }
@@ -388,7 +394,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
             securityWindow = pinOverlay
             pinOverlay.makeKeyAndVisible()
             
-            vc.successCallback = {
+            vc.successCallback = { (success) in
                 postAsyncToMain {
                     self.securityWindow?.isHidden = true
                 }

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -274,6 +274,11 @@ class ChangePinSetting: Setting {
     }
     
     override func onClick(_ navigationController: UINavigationController?) {
+        if profile.prefs.boolForKey(kPrefKeyBrowserLock) == true {
+            getApp().requirePinIfNeeded(profile: profile)
+            getApp().securityViewController?.auth()
+        }
+        
         let view = PinViewController()
         navigationController?.pushViewController(view, animated: true)
     }

--- a/brave/src/frontend/PinController.swift
+++ b/brave/src/frontend/PinController.swift
@@ -13,7 +13,7 @@ struct PinUX {
     fileprivate static var ButtonSize: CGSize {
         get {
             if UIScreen.main.bounds.width < 375 {
-                return CGSize(width: 60, height: 60)
+                return CGSize(width: 55, height: 55)
             }
             else {
                 return CGSize(width: 80, height: 80)
@@ -52,7 +52,7 @@ class PinViewController: UIViewController, PinViewControllerDelegate {
         view.addSubview(pinView)
         
         let pinViewSize = pinView.frame.size
-        pinView.snp_makeConstraints { (make) in
+        pinView.snp.makeConstraints { (make) in
             make.size.equalTo(pinViewSize)
             make.center.equalTo(self.view.center).offset(0)
         }
@@ -95,7 +95,7 @@ class ConfirmPinViewController: UIViewController {
         view.addSubview(pinView)
         
         let pinViewSize = pinView.frame.size
-        pinView.snp_makeConstraints { (make) in
+        pinView.snp.makeConstraints { (make) in
             make.size.equalTo(pinViewSize)
             make.center.equalTo(self.view.center).offset(0)
         }
@@ -117,7 +117,7 @@ class PinProtectOverlayViewController: UIViewController {
     var pinView: PinLockView!
     
     var touchCanceled: Bool = false
-    var successCallback: (() -> Void)?
+    var successCallback: ((_ success: Bool) -> Void)?
     
     override func loadView() {
         super.loadView()
@@ -129,12 +129,11 @@ class PinProtectOverlayViewController: UIViewController {
         pinView.codeCallback = { code in
             if let pinLockInfo = KeychainWrapper.pinLockInfo() {
                 if code == pinLockInfo.passcode {
-                    if self.successCallback != nil {
-                        self.successCallback!()
-                    }
+                    self.successCallback?(true)
                     self.pinView.reset()
                 }
                 else {
+                    self.successCallback?(false)
                     self.pinView.tryAgain()
                 }
             }
@@ -142,12 +141,12 @@ class PinProtectOverlayViewController: UIViewController {
         view.addSubview(pinView)
         
         let pinViewSize = pinView.frame.size
-        pinView.snp_makeConstraints { (make) in
+        pinView.snp.makeConstraints { (make) in
             make.size.equalTo(pinViewSize)
             make.center.equalTo(self.view.center).offset(0)
         }
         
-        blur.snp_makeConstraints { (make) in
+        blur.snp.makeConstraints { (make) in
             make.edges.equalTo(self.view)
         }
         
@@ -185,7 +184,7 @@ class PinProtectOverlayViewController: UIViewController {
                 localizedReason: Strings.PinFingerprintUnlock,
                 reply: { [unowned self] (success, error) -> Void in
                     if success {
-                        self.successCallback?()
+                        self.successCallback?(true)
                     }
                     else {
                         self.touchCanceled = true
@@ -296,7 +295,7 @@ class PinLockView: UIView {
         let button0 = viewWithTag(10)
         let button9 = viewWithTag(9)
         var deleteButtonFrame = deleteButton.frame
-        deleteButtonFrame.center = CGPoint(x: rint((button9!.frame ?? CGRect.zero).midX), y: rint((button0!.frame ?? CGRect.zero).midY))
+        deleteButtonFrame.center = CGPoint(x: rint((button9?.frame ?? CGRect.zero).midX), y: rint((button0?.frame ?? CGRect.zero).midY))
         deleteButton.frame = deleteButtonFrame
     }
     
@@ -493,15 +492,15 @@ class PinButton: UIControl {
 extension KeychainWrapper {
     class func pinLockInfo() -> AuthenticationKeychainInfo? {
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
-        return KeychainWrapper.defaultKeychainWrapper.object(forKey: KeychainKeyPinLockInfo) as? AuthenticationKeychainInfo
+        return KeychainWrapper.standard.object(forKey: KeychainKeyPinLockInfo) as? AuthenticationKeychainInfo
     }
     
     class func setPinLockInfo(_ info: AuthenticationKeychainInfo?) {
         NSKeyedArchiver.setClassName("AuthenticationKeychainInfo", for: AuthenticationKeychainInfo.self)
         if let info = info {
-            KeychainWrapper.defaultKeychainWrapper.set(info, forKey: KeychainKeyPinLockInfo)
+            KeychainWrapper.standard.set(info, forKey: KeychainKeyPinLockInfo)
         } else {
-            KeychainWrapper.defaultKeychainWrapper.removeObject(forKey: KeychainKeyPinLockInfo)
+            KeychainWrapper.standard.removeObject(forKey: KeychainKeyPinLockInfo)
         }
     }
 }


### PR DESCRIPTION
…lso disabling pin requires auth, and toggling browser lock on will use old pin if one has been set