### PR TITLE
Temporary fix for share extensions

### DIFF
--- a/Client/Frontend/Share/ShareExtensionHelper.swift
+++ b/Client/Frontend/Share/ShareExtensionHelper.swift
@@ -95,8 +95,8 @@ extension ShareExtensionHelper: UIActivityItemSource {
     }
     
     func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivityType?) -> String {
-        // Because of our UTI declaration, this UTI now satisfies both the 1Password Extension and the usual NSURL for Share extensions.
-        return "org.appextension.fill-browser-action"
+        // Temporary solution for bug: https://github.com/agilebits/onepassword-app-extension/issues/385
+        return "public.url"
     }
 }
 


### PR DESCRIPTION
Fixes #1213 and #1124.
They had the same problem in firefox, see issue [here](https://github.com/agilebits/onepassword-app-extension/issues/385). So I just changed what they did.

This makes notes and pocket share work, but hides 1Password from action sheet. 1Password can be still accessed from password button above keyboard, so it's kind of compromise until the issue is fixed.