### PR TITLE
Updates for Xcode 9.1 compatibility

### DIFF
--- a/ThirdParty/SQLite.swift/Sources/SQLite/Core/Connection.swift
+++ b/ThirdParty/SQLite.swift/Sources/SQLite/Core/Connection.swift
@@ -29,7 +29,7 @@ import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
 #else
-import CSQLite
+import SQLite3
 #endif
 
 /// A connection to SQLite.

--- a/ThirdParty/SQLite.swift/Sources/SQLite/Core/Statement.swift
+++ b/ThirdParty/SQLite.swift/Sources/SQLite/Core/Statement.swift
@@ -27,7 +27,7 @@ import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
 #else
-import CSQLite
+import SQLite3
 #endif
 
 /// A single SQL statement.

--- a/ThirdParty/SQLite.swift/Sources/SQLite/Helpers.swift
+++ b/ThirdParty/SQLite.swift/Sources/SQLite/Helpers.swift
@@ -27,7 +27,7 @@ import sqlite3
 #elseif SQLITE_SWIFT_SQLCIPHER
 import SQLCipher
 #else
-import CSQLite
+import SQLite3
 #endif
 
 public typealias Star = (Expression<Binding>?, Expression<Binding>?) -> Expression<Void>


### PR DESCRIPTION
Between Xcode 9.0 and 9.1 (Beta) the `CSqlite` module has moved or been removed. Based on information found in [this issue](https://github.com/stephencelis/SQLite.swift/issues/664), I have changed the `CSqlite` imports to `SQLite3`.