### PR TITLE
Fix #1319, url not visible in private mode

### DIFF
--- a/Client/Frontend/Browser/BrowserLocationView.swift
+++ b/Client/Frontend/Browser/BrowserLocationView.swift
@@ -326,11 +326,18 @@ extension BrowserLocationView: Themeable {
             log.error("Unable to apply unknown theme \(themeName)")
             return
         }
-        baseURLFontColor = theme.URLFontColor!
-        hostFontColor = theme.hostFontColor!
-        fullURLFontColor = theme.textColor!
-        stopReloadButton.tintColor = theme.textColor!
-        readerModeButton.tintColor = theme.textColor!
+        
+        guard let textColor = theme.textColor, let fontColor = theme.URLFontColor, let hostColor = theme.hostFontColor else {
+            log.warning("Theme \(themeName) is missing one of required color values")
+            return
+        }
+        
+        urlTextField.textColor = textColor
+        baseURLFontColor = fontColor
+        hostFontColor = hostColor
+        fullURLFontColor = textColor
+        stopReloadButton.tintColor = textColor
+        readerModeButton.tintColor = textColor
         backgroundColor = theme.backgroundColor
     }
 }


### PR DESCRIPTION
`UrlTextField` theme was not applied properly.

Also unwrapped theme values to prevent crashes. Not sure if not applying a theme is better than app crash. Should never happen anyway.