### PR TITLE
Fix #1284 wrong display of toolbar with 'open in new tab' long press tap.

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ContextMenuHelperDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+ContextMenuHelperDelegate.swift
@@ -165,7 +165,8 @@ extension BrowserViewController: ContextMenuHelperDelegate {
         return UIAlertAction(title: newTabTitle, style: UIAlertActionStyle.default) {
             [weak alertController] (action: UIAlertAction) in
             alertController?.view.tag = 0 // BRAVE: clear this to allow navigation
-            if self.tabManager.tabCount == 1 { getApp().browserViewController.scrollController.showToolbars(animated: true)}
+            
+            getApp().browserViewController.scrollController.showToolbars(animated: true)
             _ = self.tabManager.addTab(NSURLRequest(url: url) as URLRequest, index: self.tabManager.currentIndex?.advanced(by: 1))
         }
     }


### PR DESCRIPTION
Condition to check if `tabCount == 1` doesn't work in private mode, as in private mode there are usually 2tabs or more(tabs from normal mode and private mode)

`showToolbars` method has a check if toolbar is already visible so we can drop `tabCount` condition altogether.