### PR TITLE
Fix lost reader button on link open; Fixes #1023

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WKNavigationDelegate.swift
@@ -6,14 +6,10 @@ private let log = Logger.browserLogger
 extension BrowserViewController: WKCompatNavigationDelegate {
 
     func webViewDidStartProvisionalNavigation(_ webView: UIWebView, url: URL?) {
-        #if !BRAVE
-            if tabManager.selectedTab?.webView !== webView {
-                return
-            }
-        #else
-            // remove the open in overlay view if it is present
-            removeOpenInView()
-        #endif
+        if tabManager.selectedTab?.webView !== webView {
+            return
+        }
+        
         updateFindInPageVisibility(false)
 
         // If we are going to navigate to a new page, hide the reader mode button. Unless we
@@ -24,6 +20,8 @@ extension BrowserViewController: WKCompatNavigationDelegate {
                 urlBar.updateReaderModeState(ReaderModeState.Unavailable)
             }
 
+            // remove the open in overlay view if it is present
+            removeOpenInView()
         }
     }
 


### PR DESCRIPTION
Legacy `#if !BRAVE` check was preventing early exit when opening a link in a background tab. Thus, `readerModeState` was improperly getting set to `.unavailable`.

Note, this essentially mirrors the [Firefox iOS implementation](https://github.com/mozilla-mobile/firefox-ios/blob/master/Client/Frontend/Browser/BrowserViewController/BrowserViewController%2BWKNavigationDelegate.swift#L23-L42) now.