### PR TITLE
Fixes #712; Prevent unnecessary word wrapping

### DIFF
--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -37,9 +37,8 @@ class Setting : NSObject {
     // Called when the cell is setup. Call if you need the default behaviour.
     func onConfigureCell(_ cell: UITableViewCell) {
         cell.detailTextLabel?.attributedText = status
-        cell.detailTextLabel?.numberOfLines = 2
+        cell.detailTextLabel?.numberOfLines = 1
         cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
-        cell.detailTextLabel?.lineBreakMode = .byWordWrapping
         cell.textLabel?.attributedText = title
         cell.textLabel?.textAlignment = textAlignment
         cell.textLabel?.numberOfLines = 0


### PR DESCRIPTION
This PR is a fix for #721 where the cell's text label would vertically offset whenever the detail text label's text wrapped on smaller devices. 

Since `SettingsTableViewController` does not use a custom table view cell subclass, the cell’s text label’s frame can’t be manipulated directly.  The unwanted vertical offset is prevented by simply preventing word wrapping and allowing detail text label to resize the text.  This change continues to follow the overall style of the rest of the view.

---
**Issue:**
<img width="383" alt="712issue" src="https://user-images.githubusercontent.com/4324674/36184221-6b6347b2-1100-11e8-8213-95bb66d0fc0e.png">

---
**Fix:**
<img width="564" alt="712fix" src="https://user-images.githubusercontent.com/4324674/36184226-6f8c5630-1100-11e8-8720-5b684da9d9ac.png">

