### PR TITLE
Disabling bookmark edit action when inside an empty bookmark folder.

### DIFF
--- a/Client/Frontend/Home/BookmarksPanel.swift
+++ b/Client/Frontend/Home/BookmarksPanel.swift
@@ -269,7 +269,13 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         switchTableEditingMode(true)
     }
 
-    
+    func checkDisableEdit() {
+        if self.currentFolder != nil {
+            let bookMarkCount = self.frc?.fetchedObjects?.count ?? 0
+            editBookmarksButton.isEnabled = bookMarkCount > 0
+        }
+    }
+
     func switchTableEditingMode(_ forceOff:Bool = false) {
         let editMode:Bool = forceOff ? false : !tableView.isEditing
         tableView.setEditing(editMode, animated: forceOff ? false : true)
@@ -281,6 +287,9 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
     }
     
     func updateEditBookmarksButton(_ tableIsEditing:Bool) {
+        if tableIsEditing == false {
+            checkDisableEdit()
+        }
         self.editBookmarksButton.title = tableIsEditing ? Strings.Done : Strings.Edit
         self.editBookmarksButton.style = tableIsEditing ? .done : .plain
     }
@@ -317,6 +326,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
         
         // This removes the small top border from the toolbar
         editBookmarksToolbar.clipsToBounds = true
+
+        checkDisableEdit()
     }
     
     func onDeleteBookmarksFolderButton() {
@@ -495,6 +506,8 @@ class BookmarksPanel: SiteTableViewController, HomePanel {
                 twoLineCell.setRightBadge(nil)
             }
         }
+
+        checkDisableEdit()
     }
     
     fileprivate func downloadFaviconsAndUpdateForUrl(_ url: URL, indexPath: IndexPath) {


### PR DESCRIPTION
Fixes #1469 

First time contributor to the browser-ios repo :) I am happy to approach this differently if there is a more appropriate/established way to approach this problem.

This is a simple fix that disables the bookmark edit action when inside a bookmark folder with no bookmarks. The check is performed in the following scenarios:

1. When navigating inside a bookmark folder
2. When a bookmark is added to a folder (If we are going from 0 -> (>=1) bookmarks, the action should become enabled again)
3. When a bookmark is removed from a folder (If we are going from 1 -> 0 bookmarks, the action should become disabled)

Total test plan specified in issue, additionally it should be tested in the following scenarios above.

cc: @jhreis @srirambv 
