### PR TITLE
Disable iCloud/iTunes backups for keychain items

### DIFF
--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -304,7 +304,7 @@ open class BrowserProfile: Profile {
         
         let Length: UInt = 256
         let secret = Bytes.generateRandomBytes(Length).base64EncodedString
-        self.keychain.set(secret, forKey: key)
+        self.keychain.set(secret, forKey: key, withAccessibility: .afterFirstUnlockThisDeviceOnly)
         return secret
     }()
 

--- a/Shared/AuthenticationKeychainInfo.swift
+++ b/Shared/AuthenticationKeychainInfo.swift
@@ -22,13 +22,13 @@ public enum PasscodeInterval: Int {
 public extension KeychainWrapper {
     func authenticationInfo() -> AuthenticationKeychainInfo? {
         NSKeyedUnarchiver.setClass(AuthenticationKeychainInfo.self, forClassName: "AuthenticationKeychainInfo")
-        return object(forKey: KeychainKeyAuthenticationInfo) as? AuthenticationKeychainInfo
+        return object(forKey: KeychainKeyAuthenticationInfo, withAccessibility: .afterFirstUnlockThisDeviceOnly) as? AuthenticationKeychainInfo
     }
 
     func setAuthenticationInfo(_ info: AuthenticationKeychainInfo?) {
         NSKeyedArchiver.setClassName("AuthenticationKeychainInfo", for: AuthenticationKeychainInfo.self)
         if let info = info {
-            set(info, forKey: KeychainKeyAuthenticationInfo)
+            set(info, forKey: KeychainKeyAuthenticationInfo, withAccessibility: .afterFirstUnlockThisDeviceOnly)
         } else {
             removeObject(forKey: KeychainKeyAuthenticationInfo)
         }

--- a/Shared/KeychainCache.swift
+++ b/Shared/KeychainCache.swift
@@ -55,7 +55,7 @@ open class KeychainCache<T: JSONLiteralConvertible> {
         // TODO: PII logging.
         if let value = value,
             let jsonString = value.asJSON().stringValue() {
-            KeychainWrapper.sharedAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)")
+            KeychainWrapper.sharedAppContainerKeychain.set(jsonString, forKey: "\(branch).\(label)", withAccessibility: .afterFirstUnlockThisDeviceOnly)
         } else {
             KeychainWrapper.sharedAppContainerKeychain.removeObject(forKey: "\(branch).\(label)")
         }

--- a/brave/src/sync/Sync.swift
+++ b/brave/src/sync/Sync.swift
@@ -210,7 +210,7 @@ class Sync: JSInjector {
                 return nil
             }
             
-            return KeychainWrapper.standard.string(forKey: prefNameSeed)
+            return KeychainWrapper.standard.string(forKey: prefNameSeed, withAccessibility: .afterFirstUnlockThisDeviceOnly)
         }
         set(value) {
             // TODO: Move syncSeed validation here, remove elsewhere
@@ -222,7 +222,7 @@ class Sync: JSInjector {
             }
             
             if let value = value {
-                KeychainWrapper.standard.set(value, forKey: prefNameSeed)
+                KeychainWrapper.standard.set(value, forKey: prefNameSeed, withAccessibility: .afterFirstUnlockThisDeviceOnly)
                 // Here, we are storing a value to signify a group has been joined
                 //  this is _only_ used on a re-installation to know that the app was deleted and re-installed
                 UserDefaults.standard.set(true, forKey: prefNameSeed)


### PR DESCRIPTION
Fixes: https://github.com/brave/browser-ios/issues/1566

When adding these items to the Keychain, sensitive data should be tagged with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, which prevents any sensitive data to be exported to iTunes and iCloud backups.