### PR TITLE
Issue 1461 Double Status Bar Side Panel Fix

### DIFF
--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -75,8 +75,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     }
 
     override func setupContainerViewSize() {
-        let h = max(UIScreen.main.bounds.height, UIScreen.main.bounds.width)
-        containerView.frame = CGRect(x: 0, y: 0, width: CGFloat(BraveUX.WidthOfSlideOut), height: h)
+        containerView.frame = CGRect(x: 0, y: 0, width: CGFloat(BraveUX.WidthOfSlideOut), height: view.frame.size.height)
         setupContainerViewContentSize()
     }
     

--- a/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
+++ b/brave/src/frontend/sidepanels/SidePanelBaseViewController.swift
@@ -51,6 +51,14 @@ class SidePanelBaseViewController : UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
     }
 
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        if containerView.frame.height != self.view.frame.height {
+            setupContainerViewSize()
+        }
+    }
+
     override func viewDidLoad() {
         viewAsScrollView().isScrollEnabled = false
 


### PR DESCRIPTION
Starting small with my first ever open source contribution! I think I've got the fork PR setup correctly, let me know if I need to change anything about that. 

Fixes: https://github.com/brave/browser-ios/issues/1461

Fixed a layout issue that would occur when SidePanelBaseVC's containe…rView got de-synced from the scrollView. This could happen in the event of the view resizing without transitioning size classes. Such as when a double status bar is displayed.

![may-17-2018 21-53-24](https://user-images.githubusercontent.com/4662442/40248158-37d07f34-5a8c-11e8-94d9-1d97cf99a88a.gif)
