### PR TITLE
Fix #1602, fallback icon logic for tab tray icons.

### DIFF
--- a/Client/Frontend/Browser/TabTrayController.swift
+++ b/Client/Frontend/Browser/TabTrayController.swift
@@ -926,16 +926,7 @@ fileprivate class TabManagerDataSource: NSObject, UICollectionViewDataSource {
             }
             else {
                 postAsyncToMain {
-                    cell.placeholderFavicon.sd_setImage(with: iconUrl, completed: { (img, err, type, url) in
-                        guard err == nil, let img = img else {
-                            // avoid retrying to find an icon when none can be found, hack skips FaviconFetch
-                            ImageCache.shared.cache(FaviconFetcher.defaultFavicon, url: cacheWithUrl, type: .square, callback: nil)
-                            cell.placeholderFavicon.image = FaviconFetcher.defaultFavicon
-                            return
-                        }
-                        ImageCache.shared.cache(img, url: cacheWithUrl, type: .square, callback: nil)
-                        cell.favicon.image = img
-                    })
+                    cell.favicon.setFaviconImage(with: iconUrl, cacheUrl: cacheWithUrl)
                 }
             }
         })


### PR DESCRIPTION
The problem was that tab tray was caching low-resolution favicons and it updated favicons in other places(bookmarks, history, favorites).
Now the fallback icon logic is preserved in all places related to showing favicons.