### PR TITLE
Bitwarden should be in upper case nowadays

### DIFF
--- a/brave/src/page-hooks/LoginsHelper+1PW.swift
+++ b/brave/src/page-hooks/LoginsHelper+1PW.swift
@@ -70,7 +70,7 @@ enum ThirdPartyPasswordManagerType: Int {
         .showPicker : Strings.ShowPicker,
         .onePassword : "1Password",
         .lastPass : "LastPass",
-        .bitwarden : "bitwarden",
+        .bitwarden : "Bitwarden",
         .trueKey : "True Key"
     ]
     


### PR DESCRIPTION
This just simply changes the name to have an upper case B instead of a lower case 👍