### PR TITLE
Fix #1744, layout problems for 2018 iPhones

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -463,7 +463,7 @@ class BrowserViewController: UIViewController {
         log.debug("BVC done.")
 
         // Updating footer contraints in viewSafeAreaInsetsDidChange, doesn't work when view is loaded so we do it here.
-        if #available(iOS 11.0, *), DeviceDetector.iPhoneX {
+        if #available(iOS 11.0, *) {
             footerBackground?.snp.updateConstraints { make in
                 make.bottom.equalTo(self.footer).inset(self.view.safeAreaInsets.bottom)
             }
@@ -471,7 +471,7 @@ class BrowserViewController: UIViewController {
     }
     
     override func viewSafeAreaInsetsDidChange() {
-        if #available(iOS 11.0, *), DeviceDetector.iPhoneX {
+        if #available(iOS 11.0, *) {
             let keyboardHeight = keyboardState?.intersectionHeightForView(self.view) ?? 0
             adjustFindInPageBar(safeArea: keyboardHeight == 0)
         }
@@ -748,7 +748,7 @@ class BrowserViewController: UIViewController {
         urlBar.setNeedsUpdateConstraints()
         
         webViewContainer.snp.remakeConstraints { make in
-            if #available(iOS 11.0, *), DeviceDetector.iPhoneX {
+            if #available(iOS 11.0, *) {
                 make.left.equalTo(self.view.safeAreaLayoutGuide.snp.left)
                 make.right.equalTo(self.view.safeAreaLayoutGuide.snp.right)
             } else {
@@ -1141,9 +1141,9 @@ class BrowserViewController: UIViewController {
     }
     
     /// There is only one case when search bar needs additional bottom inset:
-    /// iPhoneX horizontal with keyboard hidden.
+    /// iPhoneX* horizontal with keyboard hidden.
     fileprivate func adjustFindInPageBar(safeArea: Bool) {
-        if #available(iOS 11, *), DeviceDetector.iPhoneX, let bar = findInPageBar {
+        if #available(iOS 11, *), let bar = findInPageBar {
             bar.snp.updateConstraints { make in
                 if safeArea && BraveApp.isIPhoneLandscape() {
                     make.bottom.equalTo(findInPageContainer).inset(self.view.safeAreaInsets.bottom)

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -169,7 +169,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
         searchEngineScrollView.snp.remakeConstraints { make in
             
-            if #available(iOS 11, *), DeviceDetector.iPhoneX {
+            if #available(iOS 11, *) {
                 make.left.equalTo(self.view.safeAreaLayoutGuide.snp.left)
                 make.right.equalTo(self.view.safeAreaLayoutGuide.snp.right)
                 
@@ -192,7 +192,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     }
     
     override func viewSafeAreaInsetsDidChange() {
-        if #available(iOS 11, *), DeviceDetector.iPhoneX {
+        if #available(iOS 11, *) {
             searchButton.snp.updateConstraints { make in
                 make.left.equalTo(self.view.safeAreaInsets).offset(searchButtonLeftOffset)
             }
@@ -337,7 +337,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
 
         prompt.snp.makeConstraints { make in
             make.top.equalTo(self.view)
-            if #available(iOS 11, *), DeviceDetector.iPhoneX {
+            if #available(iOS 11, *) {
                 make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading)
                 make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing)
             } else {
@@ -376,7 +376,7 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
     
     /// Returns custom offset on ipX horizontal to get search button nicely aligned.
     var searchButtonLeftOffset: CGFloat {
-        if #available(iOS 11, *), DeviceDetector.iPhoneX, BraveApp.isIPhoneLandscape() {
+        if #available(iOS 11, *), BraveApp.isIPhoneLandscape() {
             return 8
         } else {
             return SearchViewControllerUX.PromptInsets.left

--- a/Client/Frontend/Home/TopSitesPanel.swift
+++ b/Client/Frontend/Home/TopSitesPanel.swift
@@ -295,8 +295,8 @@ class TopSitesPanel: UIViewController, HomePanel {
     
     override func viewSafeAreaInsetsDidChange() {
         // Not sure why but when a side panel is opened and you transition from portait to landscape
-        // top site cells are misaligned, this is a workaroud for this edge case. Happens only on iPhoneX.
-        if #available(iOS 11.0, *), DeviceDetector.iPhoneX {
+        // top site cells are misaligned, this is a workaroud for this edge case. Happens only on iPhoneX*.
+        if #available(iOS 11.0, *) {
             collection.snp.remakeConstraints { make -> Void in
                 make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
                 make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)

--- a/Client/Frontend/UIConstants.swift
+++ b/Client/Frontend/UIConstants.swift
@@ -15,12 +15,7 @@ public struct UIConstants {
     static let PrivateModeReaderModeBackgroundColor = BraveUX.GreyJ
 
     static let ToolbarHeight: CGFloat = 44
-    static let BottomToolbarHeight: CGFloat = {
-        if BraveApp.isIPhoneX() {
-            return 44 + 34 // 34 is the bottom inset on the iPhone X
-        }
-        return 44
-    }()
+    static let BottomToolbarHeight: CGFloat = 44
     static let DefaultRowHeight: CGFloat = 58
     static let DefaultPadding: CGFloat = 12
     static let SnackbarButtonHeight: CGFloat = 48

--- a/DeviceDetector.swift
+++ b/DeviceDetector.swift
@@ -9,10 +9,6 @@ struct DeviceDetector {
     static var iPhone4s: Bool {
         return UIScreen.main.nativeBounds.height == 960
     }
-    
-    static var iPhoneX: Bool {
-        return UIScreen.main.nativeBounds.height == 2436
-    }
 
     static let isIpad = UIDevice.current.userInterfaceIdiom == .pad
 }

--- a/brave/src/BraveApp.swift
+++ b/brave/src/BraveApp.swift
@@ -71,18 +71,6 @@ class BraveApp {
         return UIDevice.current.userInterfaceIdiom == .phone &&
             UIInterfaceOrientationIsPortrait(UIApplication.shared.statusBarOrientation)
     }
-    
-    class func isIPhoneX() -> Bool {
-        if #available(iOS 11.0, *) {
-            if isIPhonePortrait() && getApp().window!.safeAreaInsets.top > 0 {
-                return true
-            } else if isIPhoneLandscape() && (getApp().window!.safeAreaInsets.left > 0 || getApp().window!.safeAreaInsets.right > 0) {
-                return true
-            }
-        }
-        
-        return false
-    }
 
     class func setupCacheDefaults() {
         URLCache.shared.memoryCapacity = 6 * 1024 * 1024; // 6 MB

--- a/brave/src/frontend/BraveScrollController.swift
+++ b/brave/src/frontend/BraveScrollController.swift
@@ -210,7 +210,8 @@ private extension BraveScrollController {
                     scrollWithDelta(delta)
                 }
                 
-                if headerTopOffset == -topScrollHeight && footerBottomOffset == footerHeight { // Need to check both heights since on iPhone X footer may be taller
+                // Need to check both heights since on iPhone X* footer may be taller
+                if headerTopOffset == -topScrollHeight && footerBottomOffset == footerHeight {
                     toolbarState = .collapsed
                 } else if headerTopOffset == 0 {
                     toolbarState = .visible

--- a/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
+++ b/brave/src/frontend/sidepanels/BraveRightSidePanel.swift
@@ -46,7 +46,7 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
 
     let ui_edgeInset = CGFloat(20)
     var ui_rightEdgeInset: CGFloat {
-        if #available(iOS 11, *), DeviceDetector.iPhoneX, BraveApp.isIPhoneLandscape() {
+        if #available(iOS 11, *), BraveApp.isIPhoneLandscape() {
             return self.view.safeAreaInsets.right
         } else {
             return 20
@@ -133,16 +133,16 @@ class BraveRightSidePanelViewController : SidePanelBaseViewController {
     override func viewSafeAreaInsetsDidChange() {
         if !view.isHidden {
             updateConstraintsForPanelSections()
-            updateHorizontalConstraintsForIphoneX()
+            updateHorizontalConstraintsForSafeArea()
         }
     }
     
     override func setupConstraints() {
         super.setupConstraints()
-        updateHorizontalConstraintsForIphoneX()
+        updateHorizontalConstraintsForSafeArea()
     }
     
-    private func updateHorizontalConstraintsForIphoneX() {
+    private func updateHorizontalConstraintsForSafeArea() {
         shieldToggle.snp.updateConstraints { make in
             make.right.equalTo(headerContainer.superview!).inset(ui_rightEdgeInset)
         }

--- a/brave/src/frontend/sidepanels/MainSidePanelViewController.swift
+++ b/brave/src/frontend/sidepanels/MainSidePanelViewController.swift
@@ -140,7 +140,7 @@ class MainSidePanelViewController : SidePanelBaseViewController {
         topButtonsView.snp.remakeConstraints {
             make in
             make.right.equalTo(containerView)
-            if #available(iOS 11.0, *), DeviceDetector.iPhoneX {
+            if #available(iOS 11.0, *) {
                 make.left.equalTo(containerView.safeAreaLayoutGuide.snp.left)
                 make.top.equalTo(containerView.safeAreaLayoutGuide.snp.top)
             } else {

--- a/brave/src/webview/BraveWebView.swift
+++ b/brave/src/webview/BraveWebView.swift
@@ -162,7 +162,7 @@ class BraveWebView: UIWebView {
     override func safeAreaInsetsDidChange() {
         // On Safari, scroll view indicator is next to the edge when ipX is in landscape and notch is on the left
         // We need to adjust inset for this only screen configuration.
-        if #available(iOS 11, *), DeviceDetector.iPhoneX {
+        if #available(iOS 11, *) {
             let isLandscapeLeft = UIDevice.current.orientation == UIDeviceOrientation.landscapeLeft
             // No easy way to get right inset, using hardcoded value
             scrollView.scrollIndicatorInsets.right = isLandscapeLeft ? -44 : 0


### PR DESCRIPTION
Due to Apple introducing many new iPhones with notch, iPhone X specific checks needs to be dropped.

They were put there in first place to reduce number of constraint update calls, when most of phones were not using safe area.