### PR TITLE
Fix #1733 address bar spoofing.

### DIFF
--- a/brave/src/webview/BraveWebView.swift
+++ b/brave/src/webview/BraveWebView.swift
@@ -737,7 +737,7 @@ extension BraveWebView: UIWebViewDelegate {
         }
 
         let locationChanged = BraveWebView.isTopFrameRequest(request) && url.absoluteString != URL?.absoluteString
-        if locationChanged {
+        if locationChanged && url.port == nil {
             blankTargetLinkDetectionOn = true
             // TODO Maybe separate page unload from link clicked.
             NotificationCenter.default.post(name: Notification.Name(rawValue: kNotificationPageUnload), object: self)


### PR DESCRIPTION
This is a temporary solution until we switch to WKWebView. 
We block url requests with custom port, local server pages(home tab, error pages) on port 5309 are still showing