### PR TITLE
Core data fault in history panel fix.

### DIFF
--- a/Client/Frontend/Home/HistoryPanel.swift
+++ b/Client/Frontend/Home/HistoryPanel.swift
@@ -145,8 +145,7 @@ class HistoryPanel: SiteTableViewController, HomePanel {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
-    // Minimum of 1 section
-    func numberOfSectionsInTableView(_ tableView: UITableView) -> Int {
+    func numberOfSections(in tableView: UITableView) -> Int {
         let count = frc?.sections?.count ?? 0
         return count
     }


### PR DESCRIPTION
Number of sections method changed its signature.

This is fixed in 1.7 already.