### PR TITLE
Fix #1783, fix #1784, disable sync initialization if no internet connection.

### DIFF
--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -425,6 +425,8 @@ extension Strings {
     public static let CopiedToClipboard = NSLocalizedString("Copied to Clipboard!", comment: "Copied codewords title")
     public static let SyncBookmarksCallout = NSLocalizedString("Sync your bookmarks \racross devices", comment: "Sync your bookmarks callout")
     public static let Syncing = NSLocalizedString("Syncing...", comment: "Syncing in progress label")
+    public static let SyncNoConnectionTitle = NSLocalizedString("Can't connect to sync", comment: "No internet connection alert title.")
+    public static let SyncNoConnectionBody = NSLocalizedString("Check your internet connection and try again.", comment: "No internet connection alert body.")
 }
 
 

--- a/brave/src/frontend/sync/SyncPairCameraViewController.swift
+++ b/brave/src/frontend/sync/SyncPairCameraViewController.swift
@@ -41,6 +41,11 @@ class SyncPairCameraViewController: SyncViewController {
         cameraView.layer.masksToBounds = true
         cameraView.scanCallback = { data in
             
+            if !DeviceInfo.hasConnectivity() {
+                self.showNoConnectionAlert()
+                return
+            }
+            
             // TODO: Check data against sync api
 
             // TODO: Functional, but needs some cleanup

--- a/brave/src/frontend/sync/SyncPairWordsViewController.swift
+++ b/brave/src/frontend/sync/SyncPairWordsViewController.swift
@@ -3,6 +3,8 @@
 import UIKit
 import Shared
 
+private let log = Logger.browserLogger
+
 class SyncPairWordsViewController: SyncViewController {
     
     var syncHandler: (([Int]?) -> ())?
@@ -120,11 +122,13 @@ class SyncPairWordsViewController: SyncViewController {
     }
     
     @objc func SEL_done() {
-        checkCodes()
+        doIfConnected {
+            checkCodes()
+        }
     }
     
-    func checkCodes() {
-        debugPrint("check codes")
+    private func checkCodes() {
+        log.debug("check codes")
         
         func alert(title: String? = nil, message: String? = nil) {
             if Sync.shared.isInSyncGroup {

--- a/brave/src/frontend/sync/SyncSelectDeviceTypeViewController.swift
+++ b/brave/src/frontend/sync/SyncSelectDeviceTypeViewController.swift
@@ -141,7 +141,9 @@ class SyncSelectDeviceTypeViewController: SyncViewController {
     }
 
     @objc func addDevice(sender: SyncDeviceTypeButton) {
-        syncInitHandler?(sender.label.text ?? "", sender.type)
+        doIfConnected {
+            self.syncInitHandler?(sender.label.text ?? "", sender.type)
+        }
     }
 }
 

--- a/brave/src/frontend/sync/SyncViewController.swift
+++ b/brave/src/frontend/sync/SyncViewController.swift
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import Shared
 
 struct SyncUX {
     static let backgroundColor = UIColor(rgb: 0xF8F8F8)
@@ -19,5 +20,26 @@ class SyncViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = SyncUX.backgroundColor
+    }
+    
+    func showNoConnectionAlert() {
+        let alert = UIAlertController(title: Strings.SyncNoConnectionTitle,
+                                      message: Strings.SyncNoConnectionBody, preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: Strings.OK, style: .default)
+        alert.addAction(okAction)
+        
+        present(alert, animated: true)
+    }
+    
+    /// Perform a block of code only if user has a network connection, shows an error alert otherwise.
+    /// Most of sync initialization methods require an internet connection.
+    func doIfConnected(code: () -> ()) {
+        if !DeviceInfo.hasConnectivity() {
+            showNoConnectionAlert()
+            return
+        }
+        
+        code()
     }
 }


### PR DESCRIPTION
We should disable users option to join sync group if they are not connected to network.

There's still one more unhandled egde case when the internet connection breaks during joining a sync group.