### PR TITLE
Persist baseSyncOrder between app launches.

### DIFF
--- a/brave/src/sync/Sync.swift
+++ b/brave/src/sync/Sync.swift
@@ -96,13 +96,23 @@ class Sync: JSInjector {
     }
     
     fileprivate var fetchTimer: Timer?
-    var baseSyncOrder: String?
+    
+    var baseSyncOrder: String? {
+        get {
+            return UserDefaults.standard.string(forKey: prefBaseOrder)
+        }
+        set(value) {
+            UserDefaults.standard.set(value, forKey: prefBaseOrder)
+            UserDefaults.standard.synchronize()
+        }
+    }
 
     // TODO: Move to a better place
     fileprivate let prefNameId = "device-id-js-array"
     fileprivate let prefNameName = "sync-device-name"
     fileprivate let prefNameSeed = "seed-js-array"
     fileprivate let prefFetchTimestamp = "sync-fetch-timestamp"
+    fileprivate let prefBaseOrder = "sync-base-order"
     
 //    #if DEBUG
     fileprivate let isDebug = true


### PR DESCRIPTION
Base order was in memory only. This was causing the app to not send new bookmarks after app was relaunched.

I used get/set to save to user defaults, I didn't want to use old `prefs`. We might want to use the new preferences logic once this code is ported to 1.7